### PR TITLE
chore: Remove unused dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,14 +13,11 @@ dependencies:
   path: ^1.8.2
   stack_trace: ^1.10.0
   stream_channel: ^2.1.1
-  http_methods: ^1.1.1
   mime: ^1.0.6
   convert: ^3.1.1
-  meta: ^1.8.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
   http: '>=1.0.0 <2.0.0'
   test: ^1.24.2
   test_descriptor: ^2.0.1
-


### PR DESCRIPTION
This PR removes dependencies from the pubspec.yaml file that are no longer used in the project. This cleanup helps improve project maintainability, reduces build size, and minimizes potential security risks associated with unused packages.

Closes: #12 
