### PR TITLE
refactor: Replace Object usage with strongly-typed implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ void main() async {
 
   var server = await serve(
     handler,
-    RelicHostnameAddress(hostname: 'localhost'),
+    RelicAddress.fromHostname('localhost'),
     8080,
   );
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ void main() async {
   var handler =
       const Pipeline().addMiddleware(logRequests()).addHandler(_echoRequest);
 
-  var server = await serve(handler, 'localhost', 8080);
+  var server = await serve(
+    handler,
+    RelicHostnameAddress(hostname: 'localhost'),
+    8080,
+  );
 
   // Enable content compression
   server.autoCompress = true;

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,6 @@
 include: package:lints/recommended.yaml
+
+linter:
+  rules:
+      - avoid_dynamic_calls
+      - unawaited_futures

--- a/example/example.dart
+++ b/example/example.dart
@@ -7,7 +7,8 @@ void main() async {
 
   var server = await serve(
     handler,
-    RelicAddress.fromString(address: 'localhost', port: 8080),
+    RelicHostnameAddress(hostname: 'localhost'),
+    8080,
   );
 
   // Enable content compression

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,5 +1,4 @@
 import 'package:relic/relic.dart';
-import 'package:relic/src/address/relic_address.dart';
 
 void main() async {
   var handler =
@@ -7,7 +6,7 @@ void main() async {
 
   var server = await serve(
     handler,
-    RelicHostnameAddress(hostname: 'localhost'),
+    RelicAddress.fromHostname('localhost'),
     8080,
   );
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,10 +1,14 @@
 import 'package:relic/relic.dart';
+import 'package:relic/src/address/relic_address.dart';
 
 void main() async {
   var handler =
       const Pipeline().addMiddleware(logRequests()).addHandler(_echoRequest);
 
-  var server = await serve(handler, 'localhost', 8080);
+  var server = await serve(
+    handler,
+    RelicAddress.fromString(address: 'localhost', port: 8080),
+  );
 
   // Enable content compression
   server.autoCompress = true;

--- a/lib/relic.dart
+++ b/lib/relic.dart
@@ -30,6 +30,7 @@ export 'src/middleware/middleware_extensions.dart' show MiddlewareExtensions;
 /// Relic server related exports
 export 'src/address/relic_address.dart'
     show RelicAddress, RelicHostnameAddress, RelicInternetAddress;
+export 'dart:io' show InternetAddress;
 export 'src/relic_server.dart' show RelicServer;
 export 'src/relic_server_serve.dart' show serve;
 

--- a/lib/relic.dart
+++ b/lib/relic.dart
@@ -28,8 +28,7 @@ export 'src/middleware/middleware.dart' show Middleware, createMiddleware;
 export 'src/middleware/middleware_extensions.dart' show MiddlewareExtensions;
 
 /// Relic server related exports
-export 'src/address/relic_address.dart'
-    show RelicAddress, RelicHostnameAddress, RelicInternetAddress;
+export 'src/address/relic_address.dart' show RelicAddress;
 export 'dart:io' show InternetAddress;
 export 'src/relic_server.dart' show RelicServer;
 export 'src/relic_server_serve.dart' show serve;

--- a/lib/relic.dart
+++ b/lib/relic.dart
@@ -28,6 +28,8 @@ export 'src/middleware/middleware.dart' show Middleware, createMiddleware;
 export 'src/middleware/middleware_extensions.dart' show MiddlewareExtensions;
 
 /// Relic server related exports
+export 'src/address/relic_address.dart'
+    show RelicAddress, RelicHostnameAddress, RelicInternetAddress;
 export 'src/relic_server.dart' show RelicServer;
 export 'src/relic_server_serve.dart' show serve;
 

--- a/lib/src/address/relic_address.dart
+++ b/lib/src/address/relic_address.dart
@@ -1,60 +1,42 @@
 import 'dart:io';
 
 /// A class that represents an address.
-class RelicAddress {
+abstract class RelicAddress<T> {
+  /// Returns the address as an [Object].
+  T get address;
+}
+
+/// A class that represents a hostname address.
+class RelicHostnameAddress implements RelicAddress<String> {
   /// The hostname of the address.
-  final String? hostname;
+  final String hostname;
 
-  /// The internet address of the address.
-  final InternetAddress? internetAddress;
-
-  /// The port of the address.
-  final int port;
-
-  RelicAddress._({
-    this.hostname,
-    this.internetAddress,
-    required this.port,
+  RelicHostnameAddress({
+    required this.hostname,
   });
 
-  /// Creates an address from a string.
-  factory RelicAddress.fromString({
-    required String address,
-    required int port,
-  }) {
-    return RelicAddress._(hostname: address, port: port);
-  }
-
-  /// Creates an address from an [InternetAddress].
-  factory RelicAddress.fromInternetAddress({
-    required InternetAddress address,
-    required int port,
-  }) {
-    return RelicAddress._(internetAddress: address, port: port);
-  }
-
-  /// Returns the address as an [Object].
-  Object get address => hostname ?? internetAddress!;
+  /// Returns the address as a [String].
+  @override
+  String get address => hostname;
 
   @override
-  String toString() {
-    final addr = hostname ?? internetAddress!.address;
-    return '$addr:$port';
-  }
+  String toString() => 'RelicHostnameAddress(hostname: $hostname)';
 }
 
-/// An extension on [InternetAddress] to create a [RelicAddress] with a port.
-extension InternetAddressExtension on InternetAddress {
-  /// Creates a [RelicAddress] with a port.
-  RelicAddress withPort(int port) {
-    return RelicAddress.fromInternetAddress(address: this, port: port);
-  }
-}
+/// A class that represents an internet address.
+class RelicInternetAddress implements RelicAddress<InternetAddress> {
+  /// The internet address of the address.
+  final InternetAddress internetAddress;
 
-/// An extension on [String] to create a [RelicAddress] with a port.
-extension StringExtension on String {
-  /// Creates a [RelicAddress] with a port.
-  RelicAddress withPort(int port) {
-    return RelicAddress.fromString(address: this, port: port);
-  }
+  RelicInternetAddress({
+    required this.internetAddress,
+  });
+
+  /// Returns the address as an [InternetAddress].
+  @override
+  InternetAddress get address => internetAddress;
+
+  @override
+  String toString() =>
+      'RelicInternetAddress(internetAddress: $internetAddress)';
 }

--- a/lib/src/address/relic_address.dart
+++ b/lib/src/address/relic_address.dart
@@ -4,6 +4,18 @@ import 'dart:io';
 abstract class RelicAddress<T> {
   /// Returns the address as an [Object].
   T get address;
+
+  /// Creates a [RelicAddress] from a [String].
+  static RelicAddress<String> fromHostname(String hostname) {
+    return RelicHostnameAddress(hostname: hostname);
+  }
+
+  /// Creates a [RelicAddress] from an [InternetAddress].
+  static RelicAddress<InternetAddress> fromInternetAddress(
+    InternetAddress address,
+  ) {
+    return RelicInternetAddress(internetAddress: address);
+  }
 }
 
 /// A class that represents a hostname address.

--- a/lib/src/address/relic_address.dart
+++ b/lib/src/address/relic_address.dart
@@ -1,29 +1,29 @@
 import 'dart:io';
 
 /// A class that represents an address.
-abstract class RelicAddress<T> {
+abstract final class RelicAddress<T> {
   /// Returns the address as an [Object].
   T get address;
 
   /// Creates a [RelicAddress] from a [String].
   static RelicAddress<String> fromHostname(String hostname) {
-    return RelicHostnameAddress(hostname: hostname);
+    return _RelicHostnameAddress(hostname: hostname);
   }
 
   /// Creates a [RelicAddress] from an [InternetAddress].
   static RelicAddress<InternetAddress> fromInternetAddress(
     InternetAddress address,
   ) {
-    return RelicInternetAddress(internetAddress: address);
+    return _RelicInternetAddress(internetAddress: address);
   }
 }
 
 /// A class that represents a hostname address.
-class RelicHostnameAddress implements RelicAddress<String> {
+final class _RelicHostnameAddress implements RelicAddress<String> {
   /// The hostname of the address.
   final String hostname;
 
-  RelicHostnameAddress({
+  _RelicHostnameAddress({
     required this.hostname,
   });
 
@@ -36,11 +36,11 @@ class RelicHostnameAddress implements RelicAddress<String> {
 }
 
 /// A class that represents an internet address.
-class RelicInternetAddress implements RelicAddress<InternetAddress> {
+final class _RelicInternetAddress implements RelicAddress<InternetAddress> {
   /// The internet address of the address.
   final InternetAddress internetAddress;
 
-  RelicInternetAddress({
+  _RelicInternetAddress({
     required this.internetAddress,
   });
 

--- a/lib/src/address/relic_address.dart
+++ b/lib/src/address/relic_address.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+/// A class that represents an address.
+class RelicAddress {
+  /// The hostname of the address.
+  final String? hostname;
+
+  /// The internet address of the address.
+  final InternetAddress? internetAddress;
+
+  /// The port of the address.
+  final int port;
+
+  RelicAddress._({
+    this.hostname,
+    this.internetAddress,
+    required this.port,
+  });
+
+  /// Creates an address from a string.
+  factory RelicAddress.fromString({
+    required String address,
+    required int port,
+  }) {
+    return RelicAddress._(hostname: address, port: port);
+  }
+
+  /// Creates an address from an [InternetAddress].
+  factory RelicAddress.fromInternetAddress({
+    required InternetAddress address,
+    required int port,
+  }) {
+    return RelicAddress._(internetAddress: address, port: port);
+  }
+
+  /// Returns the address as an [Object].
+  Object get address => hostname ?? internetAddress!;
+
+  @override
+  String toString() {
+    final addr = hostname ?? internetAddress!.address;
+    return '$addr:$port';
+  }
+}
+
+/// An extension on [InternetAddress] to create a [RelicAddress] with a port.
+extension InternetAddressExtension on InternetAddress {
+  /// Creates a [RelicAddress] with a port.
+  RelicAddress withPort(int port) {
+    return RelicAddress.fromInternetAddress(address: this, port: port);
+  }
+}
+
+/// An extension on [String] to create a [RelicAddress] with a port.
+extension StringExtension on String {
+  /// Creates a [RelicAddress] with a port.
+  RelicAddress withPort(int port) {
+    return RelicAddress.fromString(address: this, port: port);
+  }
+}

--- a/lib/src/headers/headers.dart
+++ b/lib/src/headers/headers.dart
@@ -1389,7 +1389,7 @@ final class _HeadersImpl extends Headers {
     return map;
   }
 
-  /// Date-related headers
+  /// Date related headers
   Map<String, DateTime?> get _dateHeadersMap => {
         Headers.dateHeader: date ?? DateTime.now().toUtc(),
         Headers.expiresHeader: expires,
@@ -1413,7 +1413,7 @@ final class _HeadersImpl extends Headers {
             accessControlRequestMethod?.value,
       };
 
-  /// List<String>-related headers
+  /// String list related headers
   Map<String, List<String>?> get _listStringHeadersMap =>
       <String, List<String>?>{
         Headers.viaHeader: via,
@@ -1422,7 +1422,7 @@ final class _HeadersImpl extends Headers {
         Headers.trailerHeader: trailer,
       };
 
-  /// Uri-related headers
+  /// Uri related headers
   Map<String, Uri?> get _uriHeadersMap => <String, Uri?>{
         Headers.locationHeader: location,
         Headers.refererHeader: referer,
@@ -1431,7 +1431,7 @@ final class _HeadersImpl extends Headers {
         Headers.hostHeader: host,
       };
 
-  /// TypedHeader-related headers
+  /// TypedHeader related headers
   Map<String, TypedHeader?> get _typedHeadersMap => <String, TypedHeader?>{
         Headers.fromHeader: from,
         Headers.acceptEncodingHeader: acceptEncoding,

--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -51,7 +51,8 @@ class RelicServer {
 
   /// Creates a server with the given parameters.
   static Future<RelicServer> createServer(
-    RelicAddress address, {
+    RelicAddress address,
+    int port, {
     SecurityContext? securityContext,
     int? backlog,
     bool shared = false,
@@ -62,13 +63,13 @@ class RelicServer {
     var server = switch (securityContext == null) {
       true => await HttpServer.bind(
           address.address,
-          address.port,
+          port,
           backlog: backlog,
           shared: shared,
         ),
       false => await HttpServer.bindSecure(
           address.address,
-          address.port,
+          port,
           securityContext!,
           backlog: backlog,
           shared: shared,

--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:relic/src/address/relic_address.dart';
 import 'package:relic/src/body/body.dart';
 import 'package:relic/src/hijack/exception/hijack_exception.dart';
 import 'package:relic/src/headers/exception/invalid_header_exception.dart';
@@ -50,8 +51,7 @@ class RelicServer {
 
   /// Creates a server with the given parameters.
   static Future<RelicServer> createServer(
-    Object address,
-    int port, {
+    RelicAddress address, {
     SecurityContext? securityContext,
     int? backlog,
     bool shared = false,
@@ -61,14 +61,14 @@ class RelicServer {
     backlog ??= 0;
     var server = switch (securityContext == null) {
       true => await HttpServer.bind(
-          address,
-          port,
+          address.address,
+          address.port,
           backlog: backlog,
           shared: shared,
         ),
       false => await HttpServer.bindSecure(
-          address,
-          port,
+          address.address,
+          address.port,
           securityContext!,
           backlog: backlog,
           shared: shared,

--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -60,21 +60,21 @@ class RelicServer {
     String? poweredByHeader,
   }) async {
     backlog ??= 0;
-    var server = switch (securityContext == null) {
-      true => await HttpServer.bind(
-          address.address,
-          port,
-          backlog: backlog,
-          shared: shared,
-        ),
-      false => await HttpServer.bindSecure(
-          address.address,
-          port,
-          securityContext!,
-          backlog: backlog,
-          shared: shared,
-        ),
-    };
+    var server = securityContext == null
+        ? await HttpServer.bind(
+            address.address,
+            port,
+            backlog: backlog,
+            shared: shared,
+          )
+        : await HttpServer.bindSecure(
+            address.address,
+            port,
+            securityContext,
+            backlog: backlog,
+            shared: shared,
+          );
+
     return RelicServer._(
       server,
       strictHeaders: strictHeaders,

--- a/lib/src/relic_server_serve.dart
+++ b/lib/src/relic_server_serve.dart
@@ -20,6 +20,7 @@ library;
 import 'dart:async';
 import 'dart:io' as io;
 
+import 'package:relic/src/address/relic_address.dart';
 import 'package:relic/src/relic_server.dart';
 
 import 'handler/handler.dart';
@@ -43,8 +44,7 @@ import 'message/response.dart';
 /// {@endtemplate}
 Future<io.HttpServer> serve(
   Handler handler,
-  Object address,
-  int port, {
+  RelicAddress address, {
   io.SecurityContext? securityContext,
   int? backlog,
   bool shared = false,
@@ -55,7 +55,6 @@ Future<io.HttpServer> serve(
 
   var server = await RelicServer.createServer(
     address,
-    port,
     securityContext: securityContext,
     backlog: backlog,
     shared: shared,

--- a/lib/src/relic_server_serve.dart
+++ b/lib/src/relic_server_serve.dart
@@ -44,7 +44,8 @@ import 'message/response.dart';
 /// {@endtemplate}
 Future<io.HttpServer> serve(
   Handler handler,
-  RelicAddress address, {
+  RelicAddress address,
+  int port, {
   io.SecurityContext? securityContext,
   int? backlog,
   bool shared = false,
@@ -55,6 +56,7 @@ Future<io.HttpServer> serve(
 
   var server = await RelicServer.createServer(
     address,
+    port,
     securityContext: securityContext,
     backlog: backlog,
     shared: shared,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   convert: ^3.1.1
 
 dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   http: '>=1.0.0 <2.0.0'
   test: ^1.24.2
   test_descriptor: ^2.0.1

--- a/test/headers/basic/access_control_allow_credentials_header_test.dart
+++ b/test/headers/basic/access_control_allow_credentials_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -21,19 +20,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -132,19 +119,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/access_control_max_age_header_test.dart
+++ b/test/headers/basic/access_control_max_age_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -113,19 +100,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/access_control_request_headers_heder_test.dart
+++ b/test/headers/basic/access_control_request_headers_heder_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -15,19 +14,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -130,19 +117,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/age_header_test.dart
+++ b/test/headers/basic/age_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -152,19 +139,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/allow_header_test.dart
+++ b/test/headers/basic/allow_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -12,19 +11,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -123,19 +110,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/content_location_header_test.dart
+++ b/test/headers/basic/content_location_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -142,19 +129,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/date_header_test.dart
+++ b/test/headers/basic/date_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -119,19 +106,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/expires_header_test.dart
+++ b/test/headers/basic/expires_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -119,19 +106,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/host_header_test.dart
+++ b/test/headers/basic/host_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -12,19 +11,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -149,19 +136,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/if_modified_since_header_test.dart
+++ b/test/headers/basic/if_modified_since_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -120,19 +107,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/last_modified_header.dart
+++ b/test/headers/basic/last_modified_header.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -120,19 +107,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/location_header_test.dart
+++ b/test/headers/basic/location_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -154,19 +141,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/max_forwards_header_test.dart
+++ b/test/headers/basic/max_forwards_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -135,19 +122,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/origin_header_test.dart
+++ b/test/headers/basic/origin_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -12,19 +11,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -154,19 +141,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/referer_header_test.dart
+++ b/test/headers/basic/referer_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -152,19 +139,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/server_header_test.dart
+++ b/test/headers/basic/server_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -12,19 +11,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -91,19 +78,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/trailer_header_test.dart
+++ b/test/headers/basic/trailer_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -110,19 +97,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/upgrade_header_test.dart
+++ b/test/headers/basic/upgrade_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -135,19 +122,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/user_agent_header_test.dart
+++ b/test/headers/basic/user_agent_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -83,19 +70,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/via_header_test.dart
+++ b/test/headers/basic/via_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -12,19 +11,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -103,19 +90,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/basic/x_powered_by_header_test.dart
+++ b/test/headers/basic/x_powered_by_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -12,19 +11,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -79,19 +66,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/custom/custom_headers_test.dart
+++ b/test/headers/custom/custom_headers_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:relic/src/headers/custom/custom_headers.dart';
 import 'package:relic/src/relic_server.dart';
 import 'package:test/test.dart';
@@ -70,19 +69,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/headers_test_utils.dart
+++ b/test/headers/headers_test_utils.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:relic/relic.dart';
 import 'package:http/http.dart' as http;
-import 'package:relic/src/address/relic_address.dart';
 
 /// Thrown when the server returns a 400 status code.
 class BadRequestException implements Exception {
@@ -22,13 +21,13 @@ Future<RelicServer> createServer({
 }) async {
   try {
     return RelicServer.createServer(
-      RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv6),
+      RelicAddress.fromInternetAddress(InternetAddress.loopbackIPv6),
       0,
       strictHeaders: strictHeaders,
     );
   } on SocketException catch (_) {
     return RelicServer.createServer(
-      RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv4),
+      RelicAddress.fromInternetAddress(InternetAddress.loopbackIPv4),
       0,
       strictHeaders: strictHeaders,
     );

--- a/test/headers/headers_test_utils.dart
+++ b/test/headers/headers_test_utils.dart
@@ -22,12 +22,14 @@ Future<RelicServer> createServer({
 }) async {
   try {
     return RelicServer.createServer(
-      InternetAddress.loopbackIPv6.withPort(0),
+      RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv6),
+      0,
       strictHeaders: strictHeaders,
     );
   } on SocketException catch (_) {
     return RelicServer.createServer(
-      InternetAddress.loopbackIPv4.withPort(0),
+      RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv4),
+      0,
       strictHeaders: strictHeaders,
     );
   }

--- a/test/headers/headers_test_utils.dart
+++ b/test/headers/headers_test_utils.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:relic/relic.dart';
 import 'package:http/http.dart' as http;
+import 'package:relic/src/address/relic_address.dart';
 
 /// Thrown when the server returns a 400 status code.
 class BadRequestException implements Exception {
@@ -10,6 +12,25 @@ class BadRequestException implements Exception {
   BadRequestException(
     this.message,
   );
+}
+
+/// Creates a [RelicServer] that listens on the loopback IPv6 address.
+/// If the IPv6 address is not available, it will listen on the loopback IPv4
+/// address.
+Future<RelicServer> createServer({
+  required bool strictHeaders,
+}) async {
+  try {
+    return RelicServer.createServer(
+      InternetAddress.loopbackIPv6.withPort(0),
+      strictHeaders: strictHeaders,
+    );
+  } on SocketException catch (_) {
+    return RelicServer.createServer(
+      InternetAddress.loopbackIPv4.withPort(0),
+      strictHeaders: strictHeaders,
+    );
+  }
 }
 
 /// Returns the headers from the server request if the server returns a 200

--- a/test/headers/typed_headers/accept_encoding_header_test.dart
+++ b/test/headers/typed_headers/accept_encoding_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -312,19 +299,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/accept_header_test.dart
+++ b/test/headers/typed_headers/accept_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -203,19 +190,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/accept_language_test.dart
+++ b/test/headers/typed_headers/accept_language_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -334,19 +321,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/accept_ranges_header_test.dart
+++ b/test/headers/typed_headers/accept_ranges_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -91,19 +78,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/access_control_allow_headers_header_test.dart
+++ b/test/headers/typed_headers/access_control_allow_headers_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -15,19 +14,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -120,19 +107,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/access_control_allow_methods_header_test.dart
+++ b/test/headers/typed_headers/access_control_allow_methods_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -15,19 +14,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -136,19 +123,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/access_control_allow_origin_header_test.dart
+++ b/test/headers/typed_headers/access_control_allow_origin_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -14,19 +13,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -177,19 +164,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/access_control_expose_headers_header_test.dart
+++ b/test/headers/typed_headers/access_control_expose_headers_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -15,19 +14,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -161,19 +148,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/access_control_request_method_header_test.dart
+++ b/test/headers/typed_headers/access_control_request_method_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:relic/src/method/request_method.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -16,19 +15,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -124,19 +111,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/authorization_header_test.dart
+++ b/test/headers/typed_headers/authorization_header_test.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
+
 import 'package:relic/src/headers/typed/headers/authorization_header.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -15,19 +15,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -455,19 +443,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/cache_control_header_test.dart
+++ b/test/headers/typed_headers/cache_control_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -310,19 +297,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/clear_site_data_header_test.dart
+++ b/test/headers/typed_headers/clear_site_data_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -133,19 +120,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/connection_header_test.dart
+++ b/test/headers/typed_headers/connection_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:relic/src/headers/headers.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -132,19 +119,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/content_disposition_header_test.dart
+++ b/test/headers/typed_headers/content_disposition_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -131,19 +118,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/content_encoding_header_test.dart
+++ b/test/headers/typed_headers/content_encoding_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -151,19 +138,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/content_language_header_test.dart
+++ b/test/headers/typed_headers/content_language_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -131,19 +118,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/content_range_header_test.dart
+++ b/test/headers/typed_headers/content_range_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -179,19 +166,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/content_security_policy_header_test.dart
+++ b/test/headers/typed_headers/content_security_policy_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -107,19 +94,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/cookie_header_test.dart
+++ b/test/headers/typed_headers/cookie_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -11,19 +10,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -209,19 +196,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/cross_origin_embedder_policy_header_test.dart
+++ b/test/headers/typed_headers/cross_origin_embedder_policy_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -14,19 +13,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -101,19 +88,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/cross_origin_opener_policy_header_test.dart
+++ b/test/headers/typed_headers/cross_origin_opener_policy_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -14,19 +13,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -97,19 +84,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/cross_origin_resource_policy_header_test.dart
+++ b/test/headers/typed_headers/cross_origin_resource_policy_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -14,19 +13,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -101,19 +88,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/etag_header_test.dart
+++ b/test/headers/typed_headers/etag_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -114,19 +101,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/expect_header_test.dart
+++ b/test/headers/typed_headers/expect_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -89,19 +76,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/from_header_test.dart
+++ b/test/headers/typed_headers/from_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -187,19 +174,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/if_match_header_test.dart
+++ b/test/headers/typed_headers/if_match_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -205,19 +192,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/if_none_match_header_test.dart
+++ b/test/headers/typed_headers/if_none_match_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -205,19 +192,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/if_range_header_test.dart
+++ b/test/headers/typed_headers/if_range_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -14,19 +13,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -133,19 +120,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/permissions_policy_header_test.dart
+++ b/test/headers/typed_headers/permissions_policy_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -102,19 +89,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/proxy_authenticate_header_test.dart
+++ b/test/headers/typed_headers/proxy_authenticate_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -11,19 +10,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -169,19 +156,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/proxy_authorization_header_test.dart
+++ b/test/headers/typed_headers/proxy_authorization_header_test.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
+
 import 'package:relic/src/headers/typed/headers/authorization_header.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -15,19 +15,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -455,19 +443,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/range_header_test.dart
+++ b/test/headers/typed_headers/range_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -192,19 +179,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/referrer_policy_header_test.dart
+++ b/test/headers/typed_headers/referrer_policy_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -95,19 +82,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/retry_after_header_test.dart
+++ b/test/headers/typed_headers/retry_after_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
@@ -14,19 +13,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -154,19 +141,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/sec_fetch_dest_header_test.dart
+++ b/test/headers/typed_headers/sec_fetch_dest_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -95,19 +82,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/sec_fetch_mode_header_test.dart
+++ b/test/headers/typed_headers/sec_fetch_mode_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -95,19 +82,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/sec_fetch_site_header_test.dart
+++ b/test/headers/typed_headers/sec_fetch_site_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -95,19 +82,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/set_cookie_header_test.dart
+++ b/test/headers/typed_headers/set_cookie_header_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -11,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -224,19 +213,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/strict_transport_security_header_test.dart
+++ b/test/headers/typed_headers/strict_transport_security_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -14,19 +13,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -149,19 +136,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/te_header_test.dart
+++ b/test/headers/typed_headers/te_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -204,19 +191,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/transfer_encoding_header_test.dart
+++ b/test/headers/typed_headers/transfer_encoding_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -126,19 +113,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/vary_header_test.dart
+++ b/test/headers/typed_headers/vary_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -129,19 +116,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/headers/typed_headers/www_authenticate_header_test.dart
+++ b/test/headers/typed_headers/www_authenticate_header_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:relic/src/headers/headers.dart';
 import 'package:relic/src/relic_server.dart';
@@ -13,19 +12,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: true,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: true,
-        );
-      }
+      server = await createServer(strictHeaders: true);
     });
 
     tearDown(() => server.close());
@@ -199,19 +186,7 @@ void main() {
     late RelicServer server;
 
     setUp(() async {
-      try {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv6,
-          0,
-          strictHeaders: false,
-        );
-      } on SocketException catch (_) {
-        server = await RelicServer.createServer(
-          InternetAddress.loopbackIPv4,
-          0,
-          strictHeaders: false,
-        );
-      }
+      server = await createServer(strictHeaders: false);
     });
 
     tearDown(() => server.close());

--- a/test/relic_server_serve_test.dart
+++ b/test/relic_server_serve_test.dart
@@ -126,6 +126,7 @@ void main() {
       Uri.http('localhost:$_serverPort', '/'),
     );
     request.sink.add([1, 2, 3, 4]);
+    // ignore: unawaited_futures
     request.sink.close();
 
     var response = await request.send();

--- a/test/relic_server_serve_test.dart
+++ b/test/relic_server_serve_test.dart
@@ -10,7 +10,6 @@ import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart' as parser;
 import 'package:relic/relic.dart';
-import 'package:relic/src/address/relic_address.dart';
 import 'package:relic/src/method/request_method.dart';
 import 'package:relic/src/relic_server_serve.dart' as relic_server;
 import 'package:test/test.dart';
@@ -286,7 +285,7 @@ void main() {
           Future(() => throw StateError('oh no'));
           return syncHandler(request);
         },
-        RelicHostnameAddress(hostname: 'localhost'),
+        RelicAddress.fromHostname('localhost'),
         0,
       );
 
@@ -306,7 +305,7 @@ void main() {
           Future(() => throw StateError('oh no'));
           return syncHandler(request);
         },
-        RelicHostnameAddress(hostname: 'localhost'),
+        RelicAddress.fromHostname('localhost'),
         0,
       );
 
@@ -417,7 +416,7 @@ void main() {
     test('can be set at the server level', () async {
       _server = await relic_server.serve(
         syncHandler,
-        RelicHostnameAddress(hostname: 'localhost'),
+        RelicAddress.fromHostname('localhost'),
         0,
         poweredByHeader: 'ourServer',
       );
@@ -438,7 +437,7 @@ void main() {
             ),
           );
         },
-        RelicHostnameAddress(hostname: 'localhost'),
+        RelicAddress.fromHostname('localhost'),
         0,
         poweredByHeader: 'ourServer',
       );
@@ -654,7 +653,7 @@ Future<void> _scheduleServer(
   assert(_server == null);
   _server = await relic_server.serve(
     handler,
-    RelicHostnameAddress(hostname: 'localhost'),
+    RelicAddress.fromHostname('localhost'),
     0,
     securityContext: securityContext,
   );

--- a/test/relic_server_serve_test.dart
+++ b/test/relic_server_serve_test.dart
@@ -286,7 +286,8 @@ void main() {
           Future(() => throw StateError('oh no'));
           return syncHandler(request);
         },
-        'localhost'.withPort(0),
+        RelicHostnameAddress(hostname: 'localhost'),
+        0,
       );
 
       var response = await http.get(Uri.http('localhost:${server.port}', '/'));
@@ -305,7 +306,8 @@ void main() {
           Future(() => throw StateError('oh no'));
           return syncHandler(request);
         },
-        'localhost'.withPort(0),
+        RelicHostnameAddress(hostname: 'localhost'),
+        0,
       );
 
       try {
@@ -415,7 +417,8 @@ void main() {
     test('can be set at the server level', () async {
       _server = await relic_server.serve(
         syncHandler,
-        'localhost'.withPort(0),
+        RelicHostnameAddress(hostname: 'localhost'),
+        0,
         poweredByHeader: 'ourServer',
       );
       var response = await _get();
@@ -435,7 +438,8 @@ void main() {
             ),
           );
         },
-        'localhost'.withPort(0),
+        RelicHostnameAddress(hostname: 'localhost'),
+        0,
         poweredByHeader: 'ourServer',
       );
 
@@ -650,7 +654,8 @@ Future<void> _scheduleServer(
   assert(_server == null);
   _server = await relic_server.serve(
     handler,
-    'localhost'.withPort(0),
+    RelicHostnameAddress(hostname: 'localhost'),
+    0,
     securityContext: securityContext,
   );
 }

--- a/test/relic_server_serve_test.dart
+++ b/test/relic_server_serve_test.dart
@@ -10,6 +10,7 @@ import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart' as parser;
 import 'package:relic/relic.dart';
+import 'package:relic/src/address/relic_address.dart';
 import 'package:relic/src/method/request_method.dart';
 import 'package:relic/src/relic_server_serve.dart' as relic_server;
 import 'package:test/test.dart';
@@ -279,10 +280,13 @@ void main() {
 
   test('passes asynchronous exceptions to the parent error zone', () async {
     await runZonedGuarded(() async {
-      var server = await relic_server.serve((request) {
-        Future(() => throw StateError('oh no'));
-        return syncHandler(request);
-      }, 'localhost', 0);
+      var server = await relic_server.serve(
+        (request) {
+          Future(() => throw StateError('oh no'));
+          return syncHandler(request);
+        },
+        'localhost'.withPort(0),
+      );
 
       var response = await http.get(Uri.http('localhost:${server.port}', '/'));
       expect(response.statusCode, HttpStatus.ok);
@@ -295,10 +299,13 @@ void main() {
 
   test("doesn't pass asynchronous exceptions to the root error zone", () async {
     var response = await Zone.root.run(() async {
-      var server = await relic_server.serve((request) {
-        Future(() => throw StateError('oh no'));
-        return syncHandler(request);
-      }, 'localhost', 0);
+      var server = await relic_server.serve(
+        (request) {
+          Future(() => throw StateError('oh no'));
+          return syncHandler(request);
+        },
+        'localhost'.withPort(0),
+      );
 
       try {
         return await http.get(Uri.http('localhost:${server.port}', '/'));
@@ -407,8 +414,7 @@ void main() {
     test('can be set at the server level', () async {
       _server = await relic_server.serve(
         syncHandler,
-        'localhost',
-        0,
+        'localhost'.withPort(0),
         poweredByHeader: 'ourServer',
       );
       var response = await _get();
@@ -428,8 +434,7 @@ void main() {
             ),
           );
         },
-        'localhost',
-        0,
+        'localhost'.withPort(0),
         poweredByHeader: 'ourServer',
       );
 
@@ -644,8 +649,7 @@ Future<void> _scheduleServer(
   assert(_server == null);
   _server = await relic_server.serve(
     handler,
-    'localhost',
-    0,
+    'localhost'.withPort(0),
     securityContext: securityContext,
   );
 }

--- a/test/relic_server_test.dart
+++ b/test/relic_server_test.dart
@@ -17,11 +17,13 @@ void main() {
   setUp(() async {
     try {
       server = await RelicServer.createServer(
-        InternetAddress.loopbackIPv6.withPort(0),
+        RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv6),
+        0,
       );
     } on SocketException catch (_) {
       server = await RelicServer.createServer(
-        InternetAddress.loopbackIPv4.withPort(0),
+        RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv4),
+        0,
       );
     }
   });

--- a/test/relic_server_test.dart
+++ b/test/relic_server_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:relic/src/address/relic_address.dart';
 import 'package:relic/src/relic_server.dart';
 import 'package:test/test.dart';
 
@@ -15,9 +16,13 @@ void main() {
 
   setUp(() async {
     try {
-      server = await RelicServer.createServer(InternetAddress.loopbackIPv6, 0);
+      server = await RelicServer.createServer(
+        InternetAddress.loopbackIPv6.withPort(0),
+      );
     } on SocketException catch (_) {
-      server = await RelicServer.createServer(InternetAddress.loopbackIPv4, 0);
+      server = await RelicServer.createServer(
+        InternetAddress.loopbackIPv4.withPort(0),
+      );
     }
   });
 

--- a/test/relic_server_test.dart
+++ b/test/relic_server_test.dart
@@ -17,12 +17,12 @@ void main() {
   setUp(() async {
     try {
       server = await RelicServer.createServer(
-        RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv6),
+        RelicAddress.fromInternetAddress(InternetAddress.loopbackIPv6),
         0,
       );
     } on SocketException catch (_) {
       server = await RelicServer.createServer(
-        RelicInternetAddress(internetAddress: InternetAddress.loopbackIPv4),
+        RelicAddress.fromInternetAddress(InternetAddress.loopbackIPv4),
         0,
       );
     }


### PR DESCRIPTION
### PR Description
This PR replaces instances of `Object` with strongly-typed implementations to improve code clarity, maintainability, and type safety. 

Key changes include:
- Introducing `RelicAddress` to encapsulate address and port handling.
- Refactoring tests to use the new `createServer` helper for consistent server setup.

No functional changes were made; this is purely a refactor for improved code quality.

Closes: https://github.com/serverpod/relic/issues/18