### PR TITLE
fix!: RelicServer cannot reliably know the Uri to use to hit it

### DIFF
--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -28,26 +28,6 @@ class RelicServer {
   /// The powered by header to use for responses.
   final String poweredByHeader;
 
-  Uri get url {
-    if (server.address.isLoopback) {
-      return Uri(scheme: 'http', host: 'localhost', port: server.port);
-    }
-
-    if (server.address.type == InternetAddressType.IPv6) {
-      return Uri(
-        scheme: 'http',
-        host: '[${server.address.address}]',
-        port: server.port,
-      );
-    }
-
-    return Uri(
-      scheme: 'http',
-      host: server.address.address,
-      port: server.port,
-    );
-  }
-
   /// Creates a server with the given parameters.
   static Future<RelicServer> createServer(
     InternetAddress address,

--- a/lib/src/relic_server_serve.dart
+++ b/lib/src/relic_server_serve.dart
@@ -21,11 +21,6 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:relic/relic.dart';
-import 'package:relic/src/relic_server.dart';
-
-import 'handler/handler.dart';
-import 'message/request.dart';
-import 'message/response.dart';
 
 /// Starts an [HttpServer] that listens on the specified [address] and
 /// [port] and sends requests to [handler].

--- a/test/headers/basic/access_control_allow_credentials_header_test.dart
+++ b/test/headers/basic/access_control_allow_credentials_header_test.dart
@@ -95,7 +95,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-allow-credentials': 'test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/access_control_max_age_header_test.dart
+++ b/test/headers/basic/access_control_max_age_header_test.dart
@@ -66,7 +66,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-max-age': 'test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/access_control_request_headers_heder_test.dart
+++ b/test/headers/basic/access_control_request_headers_heder_test.dart
@@ -48,7 +48,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-request-headers': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/age_header_test.dart
+++ b/test/headers/basic/age_header_test.dart
@@ -105,7 +105,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'age': 'invalid-age-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/allow_header_test.dart
+++ b/test/headers/basic/allow_header_test.dart
@@ -66,7 +66,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'allow': 'CUSTOM'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/content_location_header_test.dart
+++ b/test/headers/basic/content_location_header_test.dart
@@ -88,7 +88,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'content-location': 'https://example.com:test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/date_header_test.dart
+++ b/test/headers/basic/date_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'date': 'invalid-date-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/expires_header_test.dart
+++ b/test/headers/basic/expires_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'expires': 'invalid-date-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/host_header_test.dart
+++ b/test/headers/basic/host_header_test.dart
@@ -86,7 +86,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'host': 'http://example.com:test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/if_modified_since_header_test.dart
+++ b/test/headers/basic/if_modified_since_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'if-modified-since': 'invalid-date-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/if_unmodified_since_header_test.dart
+++ b/test/headers/basic/if_unmodified_since_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'if-unmodified-since': 'invalid-date-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/last_modified_header.dart
+++ b/test/headers/basic/last_modified_header.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'last-modified': 'invalid-date-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/location_header_test.dart
+++ b/test/headers/basic/location_header_test.dart
@@ -88,7 +88,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'location': 'https://example.com:test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/max_forwards_header_test.dart
+++ b/test/headers/basic/max_forwards_header_test.dart
@@ -88,7 +88,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'max-forwards': 'invalid-value'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/origin_header_test.dart
+++ b/test/headers/basic/origin_header_test.dart
@@ -87,7 +87,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'origin': 'http://example.com:test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/referer_header_test.dart
+++ b/test/headers/basic/referer_header_test.dart
@@ -88,7 +88,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'referer': 'http://example.com:test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/server_header_test.dart
+++ b/test/headers/basic/server_header_test.dart
@@ -45,7 +45,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'server': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/trailer_header_test.dart
+++ b/test/headers/basic/trailer_header_test.dart
@@ -43,7 +43,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'trailer': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/user_agent_header_test.dart
+++ b/test/headers/basic/user_agent_header_test.dart
@@ -46,7 +46,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'user-agent': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/basic/via_header_test.dart
+++ b/test/headers/basic/via_header_test.dart
@@ -44,7 +44,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'via': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/headers_test_utils.dart
+++ b/test/headers/headers_test_utils.dart
@@ -73,7 +73,7 @@ Future<Headers> getServerRequestHeaders({
   required RelicServer server,
   required Map<String, String> headers,
   // Whether to parse all headers.
-  bool parseAllHeaders = true,
+  bool eagerParseHeaders = true,
 }) async {
   Headers? parsedHeaders;
 
@@ -81,8 +81,8 @@ Future<Headers> getServerRequestHeaders({
     (Request request) {
       parsedHeaders = request.headers;
 
-      if (parseAllHeaders) {
-        parsedHeaders?.toMap(); // parse all headers eagerly (if any)
+      if (eagerParseHeaders) {
+        parsedHeaders?.toMap();
       }
 
       return Response.ok();

--- a/test/headers/typed_headers/accept_encoding_header_test.dart
+++ b/test/headers/typed_headers/accept_encoding_header_test.dart
@@ -108,7 +108,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'accept-encoding': ';q=0.5'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/accept_header_test.dart
+++ b/test/headers/typed_headers/accept_header_test.dart
@@ -62,7 +62,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'accept': 'text/html;q=abc'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/accept_language_test.dart
+++ b/test/headers/typed_headers/accept_language_test.dart
@@ -109,7 +109,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'accept-language': ';q=0.5'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/accept_ranges_header_test.dart
+++ b/test/headers/typed_headers/accept_ranges_header_test.dart
@@ -43,7 +43,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'accept-ranges': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/access_control_allow_headers_header_test.dart
+++ b/test/headers/typed_headers/access_control_allow_headers_header_test.dart
@@ -65,7 +65,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-allow-headers': '*, Content-Type'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/access_control_allow_methods_header_test.dart
+++ b/test/headers/typed_headers/access_control_allow_methods_header_test.dart
@@ -65,7 +65,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-allow-methods': 'CUSTOM'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/access_control_allow_origin_header_test.dart
+++ b/test/headers/typed_headers/access_control_allow_origin_header_test.dart
@@ -91,7 +91,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-allow-origin': 'https://example.com:test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/access_control_expose_headers_header_test.dart
+++ b/test/headers/typed_headers/access_control_expose_headers_header_test.dart
@@ -70,7 +70,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-expose-headers': '*, X-Custom-Header'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/access_control_request_method_header_test.dart
+++ b/test/headers/typed_headers/access_control_request_method_header_test.dart
@@ -70,7 +70,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'access-control-request-method': 'TEST'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/authorization_header_test.dart
+++ b/test/headers/typed_headers/authorization_header_test.dart
@@ -49,7 +49,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'authorization': 'invalid-authorization-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/cache_control_header_test.dart
+++ b/test/headers/typed_headers/cache_control_header_test.dart
@@ -132,7 +132,7 @@ void main() {
           headers: {
             'cache-control': 'max-age=3600, stale-while-revalidate=300'
           },
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/clear_site_data_header_test.dart
+++ b/test/headers/typed_headers/clear_site_data_header_test.dart
@@ -82,7 +82,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'clear-site-data': '"cache", "*", "cookies"'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
         expect(headers, isNotNull);
       },

--- a/test/headers/typed_headers/connection_header_test.dart
+++ b/test/headers/typed_headers/connection_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'connection': 'invalid-connection-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/content_disposition_header_test.dart
+++ b/test/headers/typed_headers/content_disposition_header_test.dart
@@ -43,7 +43,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'content-disposition': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/content_encoding_header_test.dart
+++ b/test/headers/typed_headers/content_encoding_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'content-encoding': 'custom-encoding'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/content_language_header_test.dart
+++ b/test/headers/typed_headers/content_language_header_test.dart
@@ -66,7 +66,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'content-language': 'en-123'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/content_range_header_test.dart
+++ b/test/headers/typed_headers/content_range_header_test.dart
@@ -109,7 +109,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'content-range': 'bytes 500-499/1234'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/content_security_policy_header_test.dart
+++ b/test/headers/typed_headers/content_security_policy_header_test.dart
@@ -43,7 +43,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'content-security-policy': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/cookie_header_test.dart
+++ b/test/headers/typed_headers/cookie_header_test.dart
@@ -103,7 +103,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'cookie': 'sessionId=abc123; userId=42\x7F'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/cross_origin_embedder_policy_header_test.dart
+++ b/test/headers/typed_headers/cross_origin_embedder_policy_header_test.dart
@@ -62,7 +62,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'cross-origin-embedder-policy': 'custom-policy'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
         expect(headers, isNotNull);
       },

--- a/test/headers/typed_headers/cross_origin_opener_policy_header_test.dart
+++ b/test/headers/typed_headers/cross_origin_opener_policy_header_test.dart
@@ -62,7 +62,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'cross-origin-opener-policy': 'custom-policy'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
         expect(headers, isNotNull);
       },

--- a/test/headers/typed_headers/cross_origin_resource_policy_header_test.dart
+++ b/test/headers/typed_headers/cross_origin_resource_policy_header_test.dart
@@ -62,7 +62,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'cross-origin-resource-policy': 'custom-policy'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
         expect(headers, isNotNull);
       },

--- a/test/headers/typed_headers/etag_header_test.dart
+++ b/test/headers/typed_headers/etag_header_test.dart
@@ -66,7 +66,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'etag': '123456'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/expect_header_test.dart
+++ b/test/headers/typed_headers/expect_header_test.dart
@@ -64,7 +64,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'expect': 'custom-directive'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/from_header_test.dart
+++ b/test/headers/typed_headers/from_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'from': 'invalid-email-format'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/if_match_header_test.dart
+++ b/test/headers/typed_headers/if_match_header_test.dart
@@ -87,7 +87,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'if-match': 'invalid-etag'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/if_none_match_header_test.dart
+++ b/test/headers/typed_headers/if_none_match_header_test.dart
@@ -87,7 +87,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'if-none-match': 'invalid-etag'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/if_range_header_test.dart
+++ b/test/headers/typed_headers/if_range_header_test.dart
@@ -67,7 +67,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'if-range': 'invalid-value'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/permissions_policy_header_test.dart
+++ b/test/headers/typed_headers/permissions_policy_header_test.dart
@@ -43,7 +43,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'permissions-policy': ''},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/proxy_authenticate_header_test.dart
+++ b/test/headers/typed_headers/proxy_authenticate_header_test.dart
@@ -42,7 +42,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'proxy-authenticate': 'Test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/proxy_authorization_header_test.dart
+++ b/test/headers/typed_headers/proxy_authorization_header_test.dart
@@ -51,7 +51,7 @@ void main() {
           headers: {
             'proxy-authorization': 'invalid-proxy-authorization-format'
           },
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/range_header_test.dart
+++ b/test/headers/typed_headers/range_header_test.dart
@@ -86,7 +86,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'range': 'invalid-value'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/referrer_policy_header_test.dart
+++ b/test/headers/typed_headers/referrer_policy_header_test.dart
@@ -61,7 +61,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'referrer-policy': 'invalid-value'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/retry_after_header_test.dart
+++ b/test/headers/typed_headers/retry_after_header_test.dart
@@ -44,7 +44,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'retry-after': 'invalid'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/sec_fetch_dest_header_test.dart
+++ b/test/headers/typed_headers/sec_fetch_dest_header_test.dart
@@ -61,7 +61,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'sec-fetch-dest': 'custom-destination'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
         expect(headers, isNotNull);
       },

--- a/test/headers/typed_headers/sec_fetch_mode_header_test.dart
+++ b/test/headers/typed_headers/sec_fetch_mode_header_test.dart
@@ -61,7 +61,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'sec-fetch-mode': 'custom-mode'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
         expect(headers, isNotNull);
       },

--- a/test/headers/typed_headers/sec_fetch_site_header_test.dart
+++ b/test/headers/typed_headers/sec_fetch_site_header_test.dart
@@ -61,7 +61,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'sec-fetch-site': 'custom-site'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
         expect(headers, isNotNull);
       },

--- a/test/headers/typed_headers/set_cookie_header_test.dart
+++ b/test/headers/typed_headers/set_cookie_header_test.dart
@@ -166,7 +166,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'set-cookie': 'userId=42\x7F'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/strict_transport_security_header_test.dart
+++ b/test/headers/typed_headers/strict_transport_security_header_test.dart
@@ -82,7 +82,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'strict-transport-security': 'max-age=abc'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/te_header_test.dart
+++ b/test/headers/typed_headers/te_header_test.dart
@@ -88,7 +88,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'te': 'trailers;q=abc'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/transfer_encoding_header_test.dart
+++ b/test/headers/typed_headers/transfer_encoding_header_test.dart
@@ -62,7 +62,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'transfer-encoding': 'custom-encoding'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/upgrade_header_test.dart
+++ b/test/headers/typed_headers/upgrade_header_test.dart
@@ -62,7 +62,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'upgrade': 'InvalidProtocol/abc'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/vary_header_test.dart
+++ b/test/headers/typed_headers/vary_header_test.dart
@@ -64,7 +64,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'vary': '* , User-Agent'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/headers/typed_headers/www_authenticate_header_test.dart
+++ b/test/headers/typed_headers/www_authenticate_header_test.dart
@@ -42,7 +42,7 @@ void main() {
         Headers headers = await getServerRequestHeaders(
           server: server,
           headers: {'www-authenticate': 'Test'},
-          parseAllHeaders: false,
+          eagerParseHeaders: false,
         );
 
         expect(headers, isNotNull);

--- a/test/relic_server_test.dart
+++ b/test/relic_server_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:relic/src/relic_server.dart';

--- a/test/relic_server_test.dart
+++ b/test/relic_server_test.dart
@@ -5,17 +5,14 @@ import 'package:http/http.dart' as http;
 import 'package:relic/src/relic_server.dart';
 import 'package:test/test.dart';
 
+import 'headers/headers_test_utils.dart';
 import 'util/test_util.dart';
 
 void main() {
   late RelicServer server;
 
   setUp(() async {
-    try {
-      server = await RelicServer.createServer(InternetAddress.loopbackIPv6, 0);
-    } on SocketException catch (_) {
-      server = await RelicServer.createServer(InternetAddress.loopbackIPv4, 0);
-    }
+    server = await createServer(strictHeaders: false);
   });
 
   tearDown(() => server.close());


### PR DESCRIPTION
- **fix!: RelicServer cannot reliably know the Uri to use to hit it**
- **test:Use expando to embellish RelicServer with a url to use for testing (avoids a larger test refactoring) - WIP**

## Description

In general a server cannot know what URL can/will be used to contact it until it sees an actual request. Previously `RelicServer` had an `url` property, which was used in the tests to know what URL to contact to hit it. 

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
~~- I have referenced at least one issue this PR fixes or is related to.~~
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
~~- I have added new tests to verify the changes.~~
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [X] Includes breaking changes.

RelicServer.url property removed

## Additional Notes
_Include any additional information or context about the PR here, if needed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified server connection logic by removing the URL retrieval functionality from the `RelicServer`.
  - Removed unnecessary import statements from the server serve functionality.

- **Tests**
  - Enhanced testing capabilities with a new extension for managing URL inference and association.
  - Streamlined server initialization process by simplifying the setup logic.
  - Updated parameter names in test cases to `eagerParseHeaders` for improved clarity and consistency in header parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->