### PR TITLE
ci: Hoist continue-on-error to job

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -21,11 +21,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         dart_sdk:
-          - "3.3.0" # ${{ env.LOWEST_DART_SDK }} won't work ¯\_(ツ)_/¯
+          # ${{ env.LOWEST_DART_SDK }} won't work at job level as env context not available for strategy ¯\_(ツ)_/¯
+          # (see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability)
+          - "3.3.0"
           - stable
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1.3
         with:
@@ -75,14 +78,16 @@ jobs:
   unit_tests:
     name: Run Unit Tests
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.dart_sdk != '3.3.0' }} # env context not available for continue-on-error
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        dart_sdk: ["3.3.0", stable, beta]
+        dart_sdk: ["3.3.0", stable, beta] # env context not available for strategy
         deps: [downgrade, upgrade]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1.3
         with:
@@ -101,13 +106,13 @@ jobs:
           dart pub get
 
       - name: Run Tests With Coverage
-        continue-on-error: ${{ matrix.dart_sdk != env.LOWEST_DART_SDK }}
         run: >-
           dart pub global activate coverage &&
           dart pub global run coverage:test_with_coverage --branch-coverage
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v5
+        if: ${{ !cancelled() }} # upload coverage irrespective of test results
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info


### PR DESCRIPTION
Move continue-on-error clause to job instead of step.

If continue-on-error is set to true on a job, then a job won't fail the workflow, but will still be marked red, on failure.
This is not the case for steps.

Also ensures we upload coverage even if there are test failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated internal workflows to enhance testing consistency and coverage reporting.
	- Improved conditions for error handling in test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->