### PR TITLE
feat: Allow a trie to be attached as a subtrie to another

### DIFF
--- a/lib/src/router/normalized_path.dart
+++ b/lib/src/router/normalized_path.dart
@@ -56,6 +56,13 @@ class NormalizedPath {
     return result;
   }
 
+  ///
+  NormalizedPath subPath(final int start, [final int? end]) =>
+      NormalizedPath._(segments.sublist(start, end));
+
+  /// The number of segments in this path
+  int get length => segments.length;
+
   /// Whether path has parameters or not
   late final bool hasParameters = segments.any((final s) => s.startsWith(':'));
 

--- a/lib/src/router/normalized_path.dart
+++ b/lib/src/router/normalized_path.dart
@@ -56,10 +56,13 @@ class NormalizedPath {
     return result;
   }
 
+  /// Whether path has parameters or not
+  late final bool hasParameters = segments.any((final s) => s.startsWith(':'));
+
   /// The string representation of the normalized path, always starting with `/`.
   ///
   /// For example, `NormalizedPath('a/b//c/./../d')` results in a path of `/a/b/d`.
-  late final path = '/${segments.join('/')}';
+  late final String path = '/${segments.join('/')}';
 
   /// Returns the normalized path string.
   @override

--- a/lib/src/router/normalized_path.dart
+++ b/lib/src/router/normalized_path.dart
@@ -56,7 +56,10 @@ class NormalizedPath {
     return result;
   }
 
+  /// Returns a new [NormalizedPath] representing a subpath of this path.
   ///
+  /// The [start] parameter specifies the starting segment index (inclusive).
+  /// The optional [end] parameter specifies the ending segment index (exclusive).
   NormalizedPath subPath(final int start, [final int? end]) =>
       NormalizedPath._(segments.sublist(start, end));
 

--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -119,11 +119,11 @@ final class PathTrie<T> {
     final currentNode = _build(normalizedPath);
 
     if (currentNode.value != null && node.value != null) {
-      throw ArgumentError('Conflicting value');
+      throw ArgumentError('Conflicting values');
     }
 
     if (currentNode.parameter != null && node.parameter != null) {
-      throw ArgumentError('Conflicting parameter');
+      throw ArgumentError('Conflicting parameters');
     }
 
     final keys = currentNode.children.keys.toSet();

--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -124,7 +124,11 @@ final class PathTrie<T> {
     final node = trie._root;
     final currentNode = _build(prefixPath);
     if (currentNode.children.containsKey(lastSegment)) {
-      throw ArgumentError('Path already exists');
+      throw ArgumentError.value(
+        normalizedPath,
+        'normalizedPath',
+        'Path already exists',
+      );
     }
 
     currentNode.children[lastSegment] = node;

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -16,10 +16,6 @@ final class Router<T> {
   /// matching and parameter extraction.
   final PathTrie<T> dynamicRoutes = PathTrie<T>();
 
-  /// Checks if a [NormalizedPath] contains any parameter segments (e.g., `:id`).
-  static bool _isDynamic(final NormalizedPath path) =>
-      path.segments.any((final s) => s.startsWith(':'));
-
   /// Adds a route definition to the router.
   ///
   /// The [path] string defines the route pattern. Segments starting with `:` (e.g.,
@@ -37,7 +33,7 @@ final class Router<T> {
   void add(final String path, final T value) {
     final normalizedPath = NormalizedPath(path);
 
-    if (_isDynamic(normalizedPath)) {
+    if (normalizedPath.hasParameters) {
       dynamicRoutes.add(normalizedPath, value);
     } else {
       if (staticRoutes.containsKey(normalizedPath)) {

--- a/test/router/path_trie_test.dart
+++ b/test/router/path_trie_test.dart
@@ -361,7 +361,6 @@ void main() {
           'Given an empty trie, '
           'when attempting to attach another trie at the root path ("/"), '
           'then it succeeds', () {
-        // This wasn't always so: https://github.com/serverpod/relic/pull/61/files#r2079670738
         expect(
           () => trieA.attach(NormalizedPath('/'), trieB),
           returnsNormally,
@@ -399,34 +398,34 @@ void main() {
         trieB.add(NormalizedPath('/'), 2);
         expect(
           () => trieA.attach(NormalizedPath('/existing'), trieB),
-          throwsArgumentError,
-          reason: 'Conflicting values',
+          throwsA(isA<ArgumentError>().having(
+              (final e) => e.message, 'message', equals('Conflicting values'))),
         );
       });
 
       test(
-          'Given a trie with an existing path, '
-          'when attempting to attach another trie at that same path that, '
-          'then it fails', () {
+          'Given a trie with an existing parameterized path, '
+          'when attempting to attach another trie with a parameterized root path at that level'
+          'then it fails due to conflicting parameters', () {
         trieA.add(NormalizedPath('/existing/:a'), 1);
         trieB.add(NormalizedPath('/:b'), 2);
         expect(
           () => trieA.attach(NormalizedPath('/existing'), trieB),
-          throwsArgumentError,
-          reason: 'Conflicting parameters',
+          throwsA(isA<ArgumentError>().having((final e) => e.message, 'message',
+              equals('Conflicting parameters'))),
         );
       });
 
       test(
           'Given a trie with an existing path, '
-          'when attempting to attach another trie at that same path that, '
-          'then it fails', () {
+          'when attempting to attach another trie such that children names would overlap, '
+          'then it fails due to conflicting children', () {
         trieA.add(NormalizedPath('/existing/foo'), 1);
         trieB.add(NormalizedPath('/foo'), 2);
         expect(
           () => trieA.attach(NormalizedPath('/existing'), trieB),
-          throwsArgumentError,
-          reason: 'Conflicting children',
+          throwsA(isA<ArgumentError>().having((final e) => e.message, 'message',
+              equals('Conflicting children'))),
         );
       });
 

--- a/test/router/path_trie_test.dart
+++ b/test/router/path_trie_test.dart
@@ -90,7 +90,7 @@ void main() {
 
       test(
           'Given a path with repeated parameters at different levels, '
-          'when looked up'
+          'when looked up, '
           'then last extracted parameter wins', () {
         trie.add(NormalizedPath('/:id/:id'), 1);
 
@@ -487,6 +487,20 @@ void main() {
             #paramB: 'val456',
           }),
         );
+      });
+
+      test(
+          'Given a path with repeated parameters at different levels introduced by attach, '
+          'when looked up, '
+          'then last extracted parameter wins', () {
+        trieA.add(NormalizedPath('/:id/'), 1);
+        trieB.add(NormalizedPath('/:id/'), 2);
+        trieA.attach(NormalizedPath('/:id/'), trieB);
+
+        final result = trieA.lookup(NormalizedPath('/123/456'));
+        expect(result, isNotNull);
+        expect(result!.value, equals(2));
+        expect(result.parameters, equals({#id: '456'}));
       });
     });
   });


### PR DESCRIPTION
## Description

Allows tries to be composed by attaching one below another.

## Related Issues
- Closes: #58

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to extract sub-paths, get path length, and detect parameters in path segments.
  - Introduced a method to attach one route trie to another at a specified subpath, enabling more flexible route management.

- **Bug Fixes**
  - Improved error handling to prevent duplicate route registrations and invalid trie attachments.

- **Tests**
  - Added comprehensive tests for attaching tries, including parameterized routes and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->