### PR TITLE
feat: Support Router.attach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pubspec.lock
 .idea/
 .vscode/
 .vscode-test/
+
+*.exe

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -57,7 +57,7 @@ class StaticAddBenchmark extends RouterBenchmark {
 class StaticLookupBenchmark extends RouterBenchmark {
   StaticLookupBenchmark() : super('Router Lookup Static x$routeCount');
 
-  late Router<int> staticRouterForLookup;
+  late final Router<int> staticRouterForLookup;
 
   @override
   void setup() {
@@ -93,7 +93,7 @@ class DynamicAddBenchmark extends RouterBenchmark {
 class DynamicLookupBenchmark extends RouterBenchmark {
   DynamicLookupBenchmark() : super('Router Lookup Dynamic x$routeCount');
 
-  late Router<int> dynamicRouterForLookup;
+  late final Router<int> dynamicRouterForLookup;
 
   @override
   void setup() {
@@ -129,7 +129,7 @@ class StaticLookupRoutingkitBenchmark extends RouterBenchmark {
   StaticLookupRoutingkitBenchmark()
       : super('Routingkit Lookup Static x$routeCount');
 
-  late kit.Router<int> staticRouterForLookup;
+  late final kit.Router<int> staticRouterForLookup;
 
   @override
   void setup() {
@@ -165,7 +165,7 @@ class DynamicLookupRoutingkitBenchmark extends RouterBenchmark {
   DynamicLookupRoutingkitBenchmark()
       : super('Routingkit Lookup Dynamic x$routeCount');
 
-  late kit.Router<int> dynamicRouterForLookup;
+  late final kit.Router<int> dynamicRouterForLookup;
 
   @override
   void setup() {

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -5,14 +5,13 @@ import 'dart:math';
 
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:relic/src/router/router.dart';
+import 'package:routingkit/routingkit.dart' as kit;
 
 const int routeCount = 10000;
 
 late final List<int> indexes;
 late final List<String> staticRoutesToLookup;
 late final List<String> dynamicRoutesToLookup;
-late final Router<int> staticRouterForLookup;
-late final Router<int> dynamicRouterForLookup;
 
 void setupBenchmarkData() {
   print('Setting up benchmark data with $routeCount routes...');
@@ -31,17 +30,6 @@ void setupBenchmarkData() {
             '/profile$i',
       )
       .toList();
-
-  // Create and populate routers specifically for lookup benchmarks
-  staticRouterForLookup = Router<int>();
-  for (final i in indexes) {
-    staticRouterForLookup.add('/path$i', i);
-  }
-
-  dynamicRouterForLookup = Router<int>();
-  for (final i in indexes) {
-    dynamicRouterForLookup.add('/users/:id/items/:itemId/profile$i', i);
-  }
   print('Setup complete.');
 }
 
@@ -69,6 +57,16 @@ class StaticAddBenchmark extends RouterBenchmark {
 class StaticLookupBenchmark extends RouterBenchmark {
   StaticLookupBenchmark() : super('Router Lookup Static x$routeCount');
 
+  late Router<int> staticRouterForLookup;
+
+  @override
+  void setup() {
+    staticRouterForLookup = Router<int>();
+    for (final i in indexes) {
+      staticRouterForLookup.add('/path$i', i);
+    }
+  }
+
   @override
   void run() {
     for (final route in staticRoutesToLookup) {
@@ -95,11 +93,95 @@ class DynamicAddBenchmark extends RouterBenchmark {
 class DynamicLookupBenchmark extends RouterBenchmark {
   DynamicLookupBenchmark() : super('Router Lookup Dynamic x$routeCount');
 
+  late Router<int> dynamicRouterForLookup;
+
+  @override
+  void setup() {
+    // Create and populate routers specifically for lookup benchmarks
+    dynamicRouterForLookup = Router<int>();
+    for (final i in indexes) {
+      dynamicRouterForLookup.add('/users/:id/items/:itemId/profile$i', i);
+    }
+  }
+
   @override
   void run() {
     for (final route in dynamicRoutesToLookup) {
       // Access value to ensure lookup isn't optimized away
       dynamicRouterForLookup.lookup(route)?.value;
+    }
+  }
+}
+
+class StaticAddRoutingkitBenchmark extends RouterBenchmark {
+  StaticAddRoutingkitBenchmark() : super('Routingkit Add Static x$routeCount');
+
+  @override
+  void run() {
+    final router = kit.createRouter<int>();
+    for (final i in indexes) {
+      router.add('GET', '/path$i', i);
+    }
+  }
+}
+
+class StaticLookupRoutingkitBenchmark extends RouterBenchmark {
+  StaticLookupRoutingkitBenchmark()
+      : super('Routingkit Lookup Static x$routeCount');
+
+  late kit.Router<int> staticRouterForLookup;
+
+  @override
+  void setup() {
+    staticRouterForLookup = kit.createRouter<int>();
+    for (final i in indexes) {
+      staticRouterForLookup.add('GET', '/path$i', i);
+    }
+  }
+
+  @override
+  void run() {
+    for (final route in staticRoutesToLookup) {
+      // Access value to ensure lookup isn't optimized away
+      staticRouterForLookup.find('GET', route)?.data;
+    }
+  }
+}
+
+class DynamicAddRoutingkitBenchmark extends RouterBenchmark {
+  DynamicAddRoutingkitBenchmark()
+      : super('Routingkit Add Dynamic x$routeCount');
+
+  @override
+  void run() {
+    final router = kit.createRouter<int>();
+    for (final i in indexes) {
+      router.add('GET', '/users/:id/items/:itemId/profile$i', i);
+    }
+  }
+}
+
+class DynamicLookupRoutingkitBenchmark extends RouterBenchmark {
+  DynamicLookupRoutingkitBenchmark()
+      : super('Routingkit Lookup Dynamic x$routeCount');
+
+  late kit.Router<int> dynamicRouterForLookup;
+
+  @override
+  void setup() {
+    // Create and populate routers specifically for lookup benchmarks
+    dynamicRouterForLookup = kit.createRouter<int>();
+    for (final i in indexes) {
+      dynamicRouterForLookup.add(
+          'GET', '/users/:id/items/:itemId/profile$i', i);
+    }
+  }
+
+  @override
+  void run() {
+    for (final route in dynamicRoutesToLookup) {
+      // Access value to ensure lookup isn't optimized away
+      dynamicRouterForLookup.find('GET', route)?.data;
     }
   }
 }
@@ -120,8 +202,12 @@ Future<void> driver() async {
 
   print('Starting benchmarks');
   StaticAddBenchmark().report();
+  StaticAddRoutingkitBenchmark().report();
   StaticLookupBenchmark().report();
+  StaticLookupRoutingkitBenchmark().report();
   DynamicAddBenchmark().report();
+  DynamicAddRoutingkitBenchmark().report();
   DynamicLookupBenchmark().report();
+  DynamicLookupRoutingkitBenchmark().report();
   print('Done');
 }

--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -8,8 +8,11 @@ final class LookupResult<T> {
   /// A map of parameter names to their extracted values from the path.
   final Map<Symbol, String> parameters;
 
+  /// Indicates whether the matched route is dynamic (contains parameters).
+  final bool isDynamic;
+
   /// Creates a [LookupResult] with the given [value] and [parameters].
-  const LookupResult(this.value, this.parameters);
+  const LookupResult(this.value, this.parameters, this.isDynamic);
 }
 
 /// A node within the path trie.
@@ -150,6 +153,7 @@ final class PathTrie<T> {
     final segments = normalizedPath.segments;
     _TrieNode<T> currentNode = _root;
     final parameters = <Symbol, String>{};
+    var isDynamic = false;
 
     for (final segment in segments) {
       final child = currentNode.children[segment];
@@ -162,6 +166,7 @@ final class PathTrie<T> {
           // Match parameter
           parameters[Symbol(parameter.name)] = segment;
           currentNode = parameter.node;
+          isDynamic = true;
         } else {
           // No match
           return null;
@@ -170,6 +175,6 @@ final class PathTrie<T> {
     }
 
     final value = currentNode.value;
-    return value != null ? LookupResult(value, parameters) : null;
+    return value != null ? LookupResult(value, parameters, isDynamic) : null;
   }
 }

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -26,8 +26,10 @@ final class Router<T> {
   void add(final String path, final T value) {
     final normalizedPath = NormalizedPath(path);
     _allRoutes.add(normalizedPath, value);
-    // Avoid possible stale cache entry, ir path is re-added.
-    _staticCache.remove(normalizedPath);
+    if (!normalizedPath.hasParameters) {
+      // Prime cache on add (but not on attach)
+      _staticCache[normalizedPath] = value;
+    }
   }
 
   /// Attaches a sub-router to this router at the specified [path].

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -26,6 +26,8 @@ final class Router<T> {
   void add(final String path, final T value) {
     final normalizedPath = NormalizedPath(path);
     _allRoutes.add(normalizedPath, value);
+    // Avoid possible stale cache entry, ir path is re-added.
+    _staticCache.remove(normalizedPath);
   }
 
   /// Attaches a sub-router to this router at the specified [path].

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -49,7 +49,7 @@ final class Router<T> {
 
     // Try cache first
     final value = _staticCache[normalizedPath];
-    if (value != null) return LookupResult(value, {}, false);
+    if (value != null) return LookupResult(value, const {}, false);
 
     // Fall back to trie
     final result = _allRoutes.lookup(normalizedPath);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
   http: ^1.0.0
   lints: ">=3.0.0 <6.0.0"
   mockito: ^5.4.4
+  routingkit: ^5.1.2
   serverpod_lints: ^2.5.0
   test: ^1.25.0
   test_descriptor: ^2.0.1

--- a/test/router/router_test.dart
+++ b/test/router/router_test.dart
@@ -21,28 +21,28 @@ void main() {
     });
 
     test(
-        'when looking up an empty string '
+        'when looking up an empty string, '
         'then it should return null', () {
       final result = router.lookup('');
       expect(result, isNull);
     });
 
     test(
-        'when looking up a non-empty string '
+        'when looking up a non-empty string, '
         'then it should return null', () {
       final result = router.lookup('/hello');
       expect(result, isNull);
     });
 
     test(
-        'when looking up the root path "/" '
+        'when looking up the root path "/", '
         'then it should return null', () {
       final result = router.lookup('/');
       expect(result, isNull);
     });
 
     test(
-        'when adding the root path "/" '
+        'when adding the root path "/", '
         'then lookup for "/" should return the correct value', () {
       router.add('/', 'root_handler');
       final result = router.lookup('/');
@@ -50,7 +50,7 @@ void main() {
     });
 
     test(
-        'when adding an empty string path '
+        'when adding an empty string path, '
         'then lookup for "/" should return the correct value', () {
       router.add('', 'empty_string_handler');
       final result = router.lookup('/');
@@ -58,7 +58,7 @@ void main() {
     });
 
     test(
-        'when adding an empty string path '
+        'when adding an empty string path, '
         'then lookup for "" should return the correct value', () {
       router.add('', 'empty_string_handler');
       final result = router.lookup('');
@@ -77,21 +77,21 @@ void main() {
     });
 
     test(
-        'when looking up the exact path '
+        'when looking up the exact path, '
         'then it should return the correct value', () {
       final result = router.lookup(path);
       expectLookupResult(result, value);
     });
 
     test(
-        'when looking up the path with a trailing slash '
+        'when looking up the path with a trailing slash, '
         'then it should return the correct value', () {
       final result = router.lookup('$path/');
       expectLookupResult(result, value);
     });
 
     test(
-        'when looking up a different path '
+        'when looking up a different path, '
         'then it should return null', () {
       final result = router.lookup('/world');
       expect(result, isNull);
@@ -109,14 +109,14 @@ void main() {
     });
 
     test(
-        'when looking up the exact path '
+        'when looking up the exact path, '
         'then it should return the correct value', () {
       final result = router.lookup(path);
       expectLookupResult(result, value);
     });
 
     test(
-        'when looking up a prefix of the path '
+        'when looking up a prefix of the path, '
         'then it should return null', () {
       final result = router.lookup('/admin/users');
       expect(result, isNull);
@@ -135,14 +135,14 @@ void main() {
     });
 
     test(
-        'when looking up the path without the slash '
+        'when looking up the path without the slash, '
         'then it should return the correct value', () {
       final result = router.lookup(pathWithoutSlash);
       expectLookupResult(result, value);
     });
 
     test(
-        'when looking up the path with the slash '
+        'when looking up the path with the slash, '
         'then it should return the correct value', () {
       final result = router.lookup(pathWithSlash);
       expectLookupResult(result, value);
@@ -163,7 +163,7 @@ void main() {
       });
 
       test(
-          'when looking up the path without the slash '
+          'when looking up the path without the slash, '
           'then it should return the correct value', () {
         final result = router.lookup(pathWithoutSlash);
         expectLookupResult(result, value);
@@ -190,7 +190,7 @@ void main() {
     });
 
     test(
-        'when adding the same path again '
+        'when adding the same path again, '
         'then it should throw ArgumentError and retain the original value', () {
       // Check that the first value is present
       var result = router.lookup(path);
@@ -225,21 +225,21 @@ void main() {
     });
 
     test(
-        'when looking up a matching path '
+        'when looking up a matching path, '
         'then it should return the value and parameter', () {
       final result = router.lookup('/users/123');
       expectLookupResult(result, value, {#id: '123'});
     });
 
     test(
-        'when looking up a non-matching path structure '
+        'when looking up a non-matching path structure, '
         'then it should return null', () {
       final result = router.lookup('/posts/123');
       expect(result, isNull);
     });
 
     test(
-        'when looking up a path matching only the prefix '
+        'when looking up a path matching only the prefix, '
         'then it should return null', () {
       final result = router.lookup('/users');
       expect(result, isNull);
@@ -256,14 +256,14 @@ void main() {
     });
 
     test(
-        'when looking up a matching path '
+        'when looking up a matching path, '
         'then it should return the value and parameter', () {
       final result = router.lookup('/report.pdf');
       expectLookupResult(result, value, {#filename: 'report.pdf'});
     });
 
     test(
-        'when looking up the root path "/" '
+        'when looking up the root path "/", '
         'then it should return null', () {
       final result = router.lookup('/');
       expect(result, isNull);
@@ -280,14 +280,14 @@ void main() {
     });
 
     test(
-        'when looking up a matching path '
+        'when looking up a matching path, '
         'then it should return the value and parameters', () {
       final result = router.lookup('/users/abc/items/xyz');
       expectLookupResult(result, value, {#userId: 'abc', #itemId: 'xyz'});
     });
 
     test(
-        'when looking up a path matching only the first parameter section '
+        'when looking up a path matching only the first parameter section, '
         'then it should return null', () {
       final result = router.lookup('/users/abc');
       expect(result, isNull);
@@ -314,14 +314,14 @@ void main() {
       });
 
       test(
-          'when looking up the details route '
+          'when looking up the details route, '
           'then it should match correctly', () {
         final result = router.lookup('/products/p100/details');
         expectLookupResult(result, 'product_details', {#productId: 'p100'});
       });
 
       test(
-          'when looking up the reviews route '
+          'when looking up the reviews route, '
           'then it should match correctly', () {
         final result = router.lookup('/products/p200/reviews/r50');
         expectLookupResult(result, 'product_review', {
@@ -349,7 +349,7 @@ void main() {
       });
 
       test(
-          'when looking up the first pattern '
+          'when looking up the first pattern, '
           'then it should match correctly', () {
         final result = router.lookup('/users/1');
         expectLookupResult(result, userValue, {#id: '1'});
@@ -370,7 +370,6 @@ void main() {
       });
     },
   );
-  // --- END NEW TEST GROUP ---
 
   group('Given a Router with a dynamic route added with a trailing slash', () {
     late Router<String> router;
@@ -558,7 +557,7 @@ void main() {
     });
 
     test(
-        'when looking up a static path '
+        'when looking up a static path, '
         'then it should return null', () {
       final result = router.lookup('/static/path');
       expect(result, isNull);
@@ -602,6 +601,67 @@ void main() {
       expectLookupResult(router.lookup('/posts/xyz/'), 'handler6', {
         #postId: 'xyz',
       });
+    });
+  });
+
+  group('Given two Router instances (mainRouter & subRouter)', () {
+    late Router<String> mainRouter;
+    late Router<String> subRouter;
+
+    setUp(() {
+      mainRouter = Router<String>();
+      subRouter = Router<String>();
+    });
+
+    group('when a sub-router with routes is attached under /parent', () {
+      setUp(() {
+        subRouter.add('/child', 'child_handler');
+        subRouter.add(
+            '', 'sub_root_handler'); // Handler at the root of subRouter
+        mainRouter.attach('/parent', subRouter);
+      });
+
+      test('then its /child route is accessible via /parent/child', () {
+        expectLookupResult(mainRouter.lookup('/parent/child'), 'child_handler');
+      });
+
+      test(
+          'then its /child route (trailing slash) is accessible via /parent/child/',
+          () {
+        expectLookupResult(
+            mainRouter.lookup('/parent/child/'), 'child_handler');
+      });
+
+      test('then its root route is accessible via /parent', () {
+        expectLookupResult(mainRouter.lookup('/parent'), 'sub_root_handler');
+      });
+
+      test('then its root route (trailing slash) is accessible via /parent/',
+          () {
+        expectLookupResult(mainRouter.lookup('/parent/'), 'sub_root_handler');
+      });
+
+      test('then a non-existent sub-route (/parent/nonexistent) returns null',
+          () {
+        expect(mainRouter.lookup('/parent/nonexistent'), isNull);
+      });
+    });
+
+    test(
+        'when a sub-route conflicts with an existing direct route, '
+        'then it throws and original route remains', () {
+      mainRouter.add('/parent/existing_child', 'direct_child_handler_on_main');
+      subRouter.add('/existing_child', 'sub_router_child_handler');
+
+      expect(
+        () => mainRouter.attach('/parent', subRouter),
+        throwsArgumentError,
+        reason: 'This would create a conflict at /parent/existing_child',
+      );
+
+      // Ensure the original direct route on mainRouter is preserved
+      expectLookupResult(mainRouter.lookup('/parent/existing_child'),
+          'direct_child_handler_on_main');
     });
   });
 }


### PR DESCRIPTION
## Description
This Pull Request introduces the `Router.attach` feature, with corresponding unit tests.

This PR changes how we optimize for static routes. Now all routes are added to the trie,
wheather they are static or not and the HashMap of static routes is purely a performance
optimization that is updated lazily on lookup.

The advantage of maintaining all routes in the trie is that it makes implementing attach
trivial.

I considered dropping the optimization for static routes completely, but maintaining it
lazily proved simple.

The PR also extends the benchmark for comparision with another router wrt. add and lookup
of dynamic and static routes.

## Related Issues
- Closes: #59
- Closes: #60  

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.


## Benchmark results:
2,4 GHz 8-Core Intel Core i9
```
./benchmark/benchmark.exe
Setting up benchmark data with 10000 routes...
Setup complete.
Starting benchmarks
Router Add Static x10000(RunTime): 5417.4670329670325 us.
Routingkit Add Static x10000(RunTime): 10859.33908045977 us.
Router Lookup Static x10000(RunTime): 1408.81 us.
Routingkit Lookup Static x10000(RunTime): 2318.04 us.
Router Add Dynamic x10000(RunTime): 26446.70707070707 us.
Routingkit Add Dynamic x10000(RunTime): 15398.784 us.
Router Lookup Dynamic x10000(RunTime): 3205.05875 us.
Routingkit Lookup Dynamic x10000(RunTime): 18607.539130434783 us.
Done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for distinguishing between static and dynamic route matches in route lookups.
  - Introduced new benchmarks for measuring performance with the `routingkit` package.

- **Bug Fixes**
  - Improved handling when attaching sub-routers, including error handling for conflicting routes.

- **Refactor**
  - Unified static and dynamic route storage into a single structure with lazy caching for static routes.
  - Localized router setup within benchmark classes for clearer benchmarking.

- **Tests**
  - Enhanced test coverage for sub-router attachment and route conflict scenarios.
  - Improved test descriptions for readability.

- **Chores**
  - Added `.exe` files to `.gitignore`.
  - Added `routingkit` to development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->