### PR TITLE
feat: Add addOrUpdate, update, and remove to PathTrie

### DIFF
--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -66,6 +66,16 @@ final class PathTrie<T> {
     currentNode.value = value;
   }
 
+  /// Adds a route path and its associated value to the trie, or updates the
+  /// value if the path already exists.
+  ///
+  /// Returns `true` if an existing value at the specific path was updated,
+  /// or `false` if a new value was added to the path (either the path was
+  /// newly created, or it existed as an intermediate path without a value).
+  ///
+  /// Throws an [ArgumentError] if [normalizedPath] contains conflicting
+  /// parameter definitions (e.g., adding `/users/:id` when `/users/:userId`
+  /// exists at the same parameter level, or if a parameter name is empty).
   bool addOrUpdate(final NormalizedPath normalizedPath, final T value) {
     final currentNode = _build(normalizedPath);
     final updated = currentNode.value != null;
@@ -73,6 +83,17 @@ final class PathTrie<T> {
     return updated;
   }
 
+  /// Updates the value associated with an existing route path.
+  ///
+  /// The [normalizedPath] must exactly match an already registered path that
+  /// currently has a value.
+  ///
+  /// Throws an [ArgumentError] if the [normalizedPath] is not found in the
+  /// trie, or if the node found at the path does not currently have a value
+  /// (i.e., it's an intermediate path segment or its value was previously removed).
+  ///
+  /// Use [addOrUpdate] to set a value on a path that might not exist or
+  /// might not currently have a value.
   void update(final NormalizedPath normalizedPath, final T value) {
     final currentNode = _find(normalizedPath);
     if (currentNode == null || currentNode.value == null) {
@@ -82,6 +103,17 @@ final class PathTrie<T> {
     currentNode.value = value;
   }
 
+  /// Removes the value associated with a specific route path.
+  ///
+  /// If found, the node's value is set to `null`.
+  /// The node itself is not removed from the trie, allowing any child paths
+  /// to remain accessible.
+  ///
+  /// The [normalizedPath] should represent the exact path definition, including
+  /// any parameter segments (e.g., `/:id`).
+  ///
+  /// Returns the value that was previously associated with the path, or `null`
+  /// if the path was not found or if the node at the path did not have a value.
   T? remove(final NormalizedPath normalizedPath) {
     final currentNode = _find(normalizedPath);
     if (currentNode == null) return null;
@@ -90,6 +122,7 @@ final class PathTrie<T> {
     return removed;
   }
 
+  /// Finds the [_TrieNode] that exactly matches the given [normalizedPath].
   _TrieNode<T>? _find(final NormalizedPath normalizedPath) {
     final segments = normalizedPath.segments;
     _TrieNode<T> currentNode = _root;

--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -115,8 +115,9 @@ final class PathTrie<T> {
   /// at `/a/b/c`, the attached trie's root will be accessible via `/a/b/c`.
   ///
   /// Throws an [ArgumentError] if:
-  /// - The node at [normalizedPath] has a value, and the root of [trie] has as well
-  /// - There are overlapping children between the node at [normalizedPath] and
+  /// - The node at [normalizedPath] has a value, and the root node of [trie] has as well.
+  /// - Both nodes has an associated parameter.
+  /// - There are overlapping children between the nodes.
   void attach(final NormalizedPath normalizedPath, final PathTrie<T> trie) {
     final node = trie._root;
     final currentNode = _build(normalizedPath);

--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -66,6 +66,48 @@ final class PathTrie<T> {
     currentNode.value = value;
   }
 
+  bool addOrUpdate(final NormalizedPath normalizedPath, final T value) {
+    final currentNode = _build(normalizedPath);
+    final updated = currentNode.value != null;
+    currentNode.value = value;
+    return updated;
+  }
+
+  void update(final NormalizedPath normalizedPath, final T value) {
+    final currentNode = _find(normalizedPath);
+    if (currentNode == null || currentNode.value == null) {
+      throw ArgumentError.value(
+          normalizedPath, 'normalizedPath', 'No value registered');
+    }
+    currentNode.value = value;
+  }
+
+  T? remove(final NormalizedPath normalizedPath) {
+    final currentNode = _find(normalizedPath);
+    if (currentNode == null) return null;
+    final removed = currentNode.value;
+    currentNode.value = null;
+    return removed;
+  }
+
+  _TrieNode<T>? _find(final NormalizedPath normalizedPath) {
+    final segments = normalizedPath.segments;
+    _TrieNode<T> currentNode = _root;
+
+    for (final segment in segments) {
+      var nextNode = currentNode.children[segment];
+      if (nextNode == null && segment.startsWith(':')) {
+        final parameter = currentNode.parameter;
+        if (parameter != null && parameter.name == segment.substring(1)) {
+          nextNode = parameter.node;
+        }
+      }
+      if (nextNode == null) return null; // early exit
+      currentNode = nextNode;
+    }
+    return currentNode;
+  }
+
   /// Builds a trie node for the given normalized path.
   _TrieNode<T> _build(final NormalizedPath normalizedPath) {
     final segments = normalizedPath.segments;

--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -69,18 +69,18 @@ final class PathTrie<T> {
   /// Adds a route path and its associated value to the trie, or updates the
   /// value if the path already exists.
   ///
-  /// Returns `true` if an existing value at the specific path was updated,
-  /// or `false` if a new value was added to the path (either the path was
-  /// newly created, or it existed as an intermediate path without a value).
+  /// Returns `true` if a new value was added to the path (either the path was
+  /// newly created, or it existed as an intermediate path without a value)
+  /// or `false` if an existing value at the specific path was updated,
   ///
   /// Throws an [ArgumentError] if [normalizedPath] contains conflicting
   /// parameter definitions (e.g., adding `/users/:id` when `/users/:userId`
   /// exists at the same parameter level, or if a parameter name is empty).
   bool addOrUpdate(final NormalizedPath normalizedPath, final T value) {
     final currentNode = _build(normalizedPath);
-    final updated = currentNode.value != null;
+    final added = currentNode.value == null;
     currentNode.value = value;
-    return updated;
+    return added;
   }
 
   /// Updates the value associated with an existing route path.

--- a/test/router/path_trie_crud_test.dart
+++ b/test/router/path_trie_crud_test.dart
@@ -1,0 +1,380 @@
+import 'package:relic/src/router/normalized_path.dart';
+import 'package:relic/src/router/path_trie.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PathTrie CRUD operations', () {
+    late PathTrie<int> trie;
+
+    setUp(() {
+      trie = PathTrie<int>();
+    });
+
+    group('addOrUpdate', () {
+      test(
+          'Given an empty trie, '
+          'when a new path is added with addOrUpdate, '
+          'then the path is added, lookup returns the value, and addOrUpdate returns false (added)',
+          () {
+        // GIVEN: an empty trie and a path
+        final path = NormalizedPath('/users');
+        const value = 1;
+
+        // WHEN: addOrUpdate is called
+        final wasUpdated = trie.addOrUpdate(path, value);
+
+        // THEN: the path is added and correct results are returned
+        final result = trie.lookup(path);
+        expect(wasUpdated, isFalse,
+            reason: 'Should return false as it was a new entry.');
+        expect(result, isNotNull);
+        expect(result!.value, equals(value));
+        expect(result.parameters, isEmpty);
+      });
+
+      test(
+          'Given a trie with an existing path, '
+          'when addOrUpdate is called for the same path with a new value, '
+          'then the value is updated, lookup returns the new value, and addOrUpdate returns true (updated)',
+          () {
+        // GIVEN: a trie with an existing path
+        final path = NormalizedPath('/users');
+        const initialValue = 1;
+        const updatedValue = 2;
+        trie.add(path, initialValue); // Pre-populate using standard add
+
+        // WHEN: addOrUpdate is called for the existing path
+        final wasUpdated = trie.addOrUpdate(path, updatedValue);
+
+        // THEN: the value is updated and correct results are returned
+        final result = trie.lookup(path);
+        expect(wasUpdated, isTrue,
+            reason: 'Should return true as it updated an existing entry.');
+        expect(result, isNotNull);
+        expect(result!.value, equals(updatedValue));
+      });
+
+      test(
+          'Given an empty trie, '
+          'when a new parameterized path is added with addOrUpdate, '
+          'then the path is added, lookup returns the value with parameters, and addOrUpdate returns false',
+          () {
+        // GIVEN: an empty trie and a parameterized path
+        final pathDefinition = NormalizedPath('/users/:id');
+        final lookupPath = NormalizedPath('/users/123');
+        const value = 1;
+
+        // WHEN: addOrUpdate is called
+        final wasUpdated = trie.addOrUpdate(pathDefinition, value);
+
+        // THEN: the path is added and correct results are returned
+        final result = trie.lookup(lookupPath);
+        expect(wasUpdated, isFalse);
+        expect(result, isNotNull);
+        expect(result!.value, equals(value));
+        expect(result.parameters, equals({#id: '123'}));
+      });
+
+      test(
+          'Given a trie with an existing parameterized path, '
+          'when addOrUpdate is called for that path with a new value, '
+          'then the value is updated, lookup returns new value with parameters, and addOrUpdate returns true',
+          () {
+        // GIVEN: a trie with an existing parameterized path
+        final pathDefinition = NormalizedPath('/users/:id');
+        final lookupPath = NormalizedPath('/users/123');
+        const initialValue = 1;
+        const updatedValue = 2;
+        trie.add(pathDefinition, initialValue);
+
+        // WHEN: addOrUpdate is called
+        final wasUpdated = trie.addOrUpdate(pathDefinition, updatedValue);
+
+        // THEN: the value is updated and correct results are returned
+        final result = trie.lookup(lookupPath);
+        expect(wasUpdated, isTrue);
+        expect(result, isNotNull);
+        expect(result!.value, equals(updatedValue));
+        expect(result.parameters, equals({#id: '123'}));
+      });
+
+      test(
+          'Given a trie with a path /a (with a value), '
+          'when addOrUpdate is called for /a/b, '
+          'then /a/b is added with its value, /a retains its value, and both are retrievable',
+          () {
+        // GIVEN: a trie with /a having a value
+        final pathA = NormalizedPath('/a');
+        final pathAB = NormalizedPath('/a/b');
+        trie.addOrUpdate(pathA, 1);
+
+        // WHEN: addOrUpdate is called for /a/b
+        final wasUpdatedAB = trie.addOrUpdate(pathAB, 2);
+
+        // THEN: /a/b is added, /a remains, both values are correct
+        expect(wasUpdatedAB, isFalse);
+        expect(trie.lookup(pathA)?.value, 1);
+        expect(trie.lookup(pathAB)?.value, 2);
+      });
+
+      test(
+          'Given a trie with a path /a/b/c (making /a/b an intermediate node), '
+          'when addOrUpdate is called for /a/b to give it a value, '
+          'then /a/b gets the value, /a/b/c remains accessible, and addOrUpdate for /a/b returns false (added value to existing node)',
+          () {
+        // GIVEN: /a/b/c exists, /a/b is intermediate without its own value
+        final pathABC = NormalizedPath('/a/b/c');
+        final pathAB = NormalizedPath('/a/b');
+        trie.addOrUpdate(pathABC, 1); // /a/b is created as an intermediate node
+
+        // WHEN: addOrUpdate is called for /a/b
+        final wasUpdatedAB = trie.addOrUpdate(pathAB, 2);
+
+        // THEN: /a/b now has a value, /a/b/c is still there
+        expect(wasUpdatedAB, isFalse,
+            reason:
+                "/a/b didn't have a value, so it's an addition of value, not an update of existing value.");
+        expect(trie.lookup(pathAB)?.value, 2);
+        expect(trie.lookup(pathABC)?.value, 1);
+      });
+    });
+
+    group('update', () {
+      test(
+          'Given a trie with an existing path and value, '
+          'when update is called with that path and a new value, '
+          'then lookup returns the new value', () {
+        // GIVEN: a path with a value
+        final path = NormalizedPath('/posts');
+        trie.add(path, 1);
+
+        // WHEN: update is called
+        trie.update(path, 2);
+
+        // THEN: the value is updated
+        final result = trie.lookup(path);
+        expect(result, isNotNull);
+        expect(result!.value, equals(2));
+      });
+
+      test(
+          'Given a trie, '
+          'when update is called for a path that does not exist, '
+          'then an ArgumentError is thrown', () {
+        // GIVEN: a path that doesn't exist
+        final path = NormalizedPath('/nonexistent');
+
+        // WHEN/THEN: update is called and throws
+        expect(() => trie.update(path, 1), throwsArgumentError);
+        expect(trie.lookup(path), isNull,
+            reason: 'Path should not have been added.');
+      });
+
+      test(
+          'Given a trie with /a/b (making /a intermediate and valueless), '
+          'when update is called for /a, '
+          'then an ArgumentError is thrown', () {
+        // GIVEN: /a is an intermediate node without a value
+        trie.add(NormalizedPath('/a/b'), 2);
+        final pathA = NormalizedPath('/a');
+
+        // WHEN/THEN: update is called for /a and throws
+        expect(() => trie.update(pathA, 1), throwsArgumentError,
+            reason:
+                "Cannot update a node that doesn't have an explicit value.");
+        expect(trie.lookup(pathA), isNull,
+            reason: '/a should not have gained a value.');
+        expect(trie.lookup(NormalizedPath('/a/b'))?.value, 2,
+            reason: 'Child path should be unaffected.');
+      });
+
+      test(
+          'Given a trie with an existing parameterized path and value, '
+          'when update is called with that path and a new value, '
+          'then lookup returns the new value', () {
+        // GIVEN: a parameterized path with a value
+        final pathDefinition = NormalizedPath('/posts/:id');
+        trie.add(pathDefinition, 1);
+
+        // WHEN: update is called
+        trie.update(pathDefinition, 2);
+
+        // THEN: the value is updated for the parameterized path
+        final result = trie.lookup(NormalizedPath('/posts/abc'));
+        expect(result, isNotNull);
+        expect(result!.value, equals(2));
+        expect(result.parameters, equals({#id: 'abc'}));
+      });
+
+      test(
+          'Given a trie, '
+          'when update is called for a parameterized path that does not exist as a defined route, '
+          'then an ArgumentError is thrown', () {
+        // GIVEN: a parameterized path that hasn't been added
+        final pathDefinition = NormalizedPath('/articles/:id');
+
+        // WHEN/THEN: update is called and throws
+        expect(() => trie.update(pathDefinition, 1), throwsArgumentError);
+        expect(trie.lookup(NormalizedPath('/articles/any')), isNull);
+      });
+    });
+
+    group('remove', () {
+      test(
+          'Given a trie with an existing leaf path and value, '
+          'when remove is called, '
+          'then it returns the removed value and lookup for that path returns null',
+          () {
+        // GIVEN: a path with a value
+        final path = NormalizedPath('/comments');
+        trie.add(path, 1);
+
+        // WHEN: remove is called
+        final removedValue = trie.remove(path);
+
+        // THEN: value is removed and correct value returned
+        expect(removedValue, equals(1));
+        expect(trie.lookup(path), isNull);
+      });
+
+      test(
+          'Given a trie, '
+          'when remove is called for a path that does not exist, '
+          'then it returns null and the trie is unchanged', () {
+        // GIVEN: a path that doesn't exist
+        final path = NormalizedPath('/comments/123');
+        trie.add(NormalizedPath('/other'), 1); // Ensure trie is not empty
+
+        // WHEN: remove is called for non-existent path
+        final removedValue = trie.remove(path);
+
+        // THEN: null is returned, other paths unaffected
+        expect(removedValue, isNull);
+        expect(trie.lookup(path), isNull);
+        expect(trie.lookup(NormalizedPath('/other'))?.value, 1);
+      });
+
+      test(
+          'Given a trie with /a/b (making /a intermediate and valueless), '
+          'when remove is called for /a, '
+          'then it returns null and /a/b is still accessible', () {
+        // GIVEN: /a is intermediate and valueless, /a/b has a value
+        final pathA = NormalizedPath('/a');
+        final pathAB = NormalizedPath('/a/b');
+        trie.add(pathAB, 2);
+
+        // WHEN: remove is called for /a
+        final removedValue = trie.remove(pathA);
+
+        // THEN: null is returned, /a/b remains
+        expect(removedValue, isNull, reason: '/a had no value to remove.');
+        expect(trie.lookup(pathA), isNull);
+        expect(trie.lookup(pathAB)?.value, 2);
+      });
+
+      test(
+          'Given a trie with /parent (value) and /parent/child (value), '
+          'when remove is called for /parent, '
+          'then /parent value is removed (returns value), lookup is null, but /parent/child is still accessible',
+          () {
+        // GIVEN: parent and child both have values
+        final parentPath = NormalizedPath('/articles');
+        final childPath = NormalizedPath('/articles/details');
+        trie.add(parentPath, 1);
+        trie.add(childPath, 2);
+
+        // WHEN: remove is called for the parent path
+        final removedValue = trie.remove(parentPath);
+
+        // THEN: parent's value is removed, child remains
+        expect(removedValue, equals(1));
+        expect(trie.lookup(parentPath), isNull,
+            reason: 'Value of /articles should be removed.');
+        expect(trie.lookup(childPath)?.value, 2,
+            reason: 'Child /articles/details should still be accessible.');
+      });
+
+      test(
+          'Given a trie with a parameterized path and value, '
+          'when remove is called, '
+          'then it returns the removed value and lookup for that parameterized path returns null',
+          () {
+        // GIVEN: a parameterized path with a value
+        final pathDefinition = NormalizedPath('/users/:id/settings');
+        trie.add(pathDefinition, 1);
+        trie.add(NormalizedPath('/users/data'), 2); // Sibling path
+
+        // WHEN: remove is called for the parameterized path definition
+        final removedValue = trie.remove(pathDefinition);
+
+        // THEN: value is removed, path no longer matches
+        expect(removedValue, equals(1));
+        expect(trie.lookup(NormalizedPath('/users/123/settings')), isNull);
+        expect(trie.lookup(NormalizedPath('/users/any/settings')), isNull);
+        expect(trie.lookup(NormalizedPath('/users/data'))?.value, 2,
+            reason: 'Sibling path should be unaffected.');
+      });
+
+      test(
+          'Given a trie with root path / (value) and child /a (value), '
+          'when remove is called for /, '
+          'then / value is removed (returns value), but /a is still accessible',
+          () {
+        // GIVEN: root and child have values
+        final rootPath = NormalizedPath('/');
+        final childPath = NormalizedPath('/a');
+        trie.add(rootPath, 1);
+        trie.add(childPath, 2);
+
+        // WHEN: remove is called for the root path
+        final removedValue = trie.remove(rootPath);
+
+        // THEN: root value is removed, child remains
+        expect(removedValue, equals(1));
+        expect(trie.lookup(rootPath), isNull);
+        expect(trie.lookup(childPath)?.value, 2);
+      });
+
+      test(
+          'Given a trie with only root path / having a value, '
+          'when remove is called for /, '
+          'then / value is removed (returns value) and lookup is null', () {
+        // GIVEN: only root has a value
+        final rootPath = NormalizedPath('/');
+        trie.add(rootPath, 1);
+
+        // WHEN: remove is called for the root path
+        final removedValue = trie.remove(rootPath);
+
+        // THEN: root value is removed
+        expect(removedValue, equals(1));
+        expect(trie.lookup(rootPath), isNull);
+      });
+
+      test(
+          'Given a trie with /a/b/c and /a/b/d, '
+          'when /a/b/c is removed, '
+          'then /a/b/d should still be accessible and /a/b (intermediate node) should not be affected.',
+          () {
+        // GIVEN: two sibling paths sharing a common prefix
+        final pathABC = NormalizedPath('/a/b/c');
+        final pathABD = NormalizedPath('/a/b/d');
+        trie.add(pathABC, 1);
+        trie.add(pathABD, 2);
+        // Optionally give /a/b a value to test its persistence
+        trie.addOrUpdate(NormalizedPath('/a/b'), 3);
+
+        // WHEN: one of the sibling paths is removed
+        final removedValue = trie.remove(pathABC);
+
+        // THEN: the removed path is gone, the other remains, intermediate nodes unchanged
+        expect(removedValue, equals(1));
+        expect(trie.lookup(pathABC), isNull);
+        expect(trie.lookup(pathABD)?.value, 2);
+        expect(trie.lookup(NormalizedPath('/a/b'))?.value, 3,
+            reason:
+                'Intermediate node /a/b should retain its value if it had one.');
+      });
+    });
+  });
+}

--- a/test/router/path_trie_crud_test.dart
+++ b/test/router/path_trie_crud_test.dart
@@ -14,19 +14,15 @@ void main() {
       test(
           'Given an empty trie, '
           'when a new path is added with addOrUpdate, '
-          'then the path is added, lookup returns the value, and addOrUpdate returns false (added)',
+          'then the path is added, lookup returns the value, and addOrUpdate returns true (added)',
           () {
-        // GIVEN: an empty trie and a path
         final path = NormalizedPath('/users');
         const value = 1;
 
-        // WHEN: addOrUpdate is called
-        final wasUpdated = trie.addOrUpdate(path, value);
+        final wasAdded = trie.addOrUpdate(path, value);
 
-        // THEN: the path is added and correct results are returned
         final result = trie.lookup(path);
-        expect(wasUpdated, isFalse,
-            reason: 'Should return false as it was a new entry.');
+        expect(wasAdded, isTrue);
         expect(result, isNotNull);
         expect(result!.value, equals(value));
         expect(result.parameters, isEmpty);
@@ -35,21 +31,16 @@ void main() {
       test(
           'Given a trie with an existing path, '
           'when addOrUpdate is called for the same path with a new value, '
-          'then the value is updated, lookup returns the new value, and addOrUpdate returns true (updated)',
-          () {
-        // GIVEN: a trie with an existing path
+          'then the value is updated', () {
         final path = NormalizedPath('/users');
         const initialValue = 1;
         const updatedValue = 2;
         trie.add(path, initialValue); // Pre-populate using standard add
 
-        // WHEN: addOrUpdate is called for the existing path
-        final wasUpdated = trie.addOrUpdate(path, updatedValue);
+        final wasAdded = trie.addOrUpdate(path, updatedValue);
 
-        // THEN: the value is updated and correct results are returned
         final result = trie.lookup(path);
-        expect(wasUpdated, isTrue,
-            reason: 'Should return true as it updated an existing entry.');
+        expect(wasAdded, isFalse);
         expect(result, isNotNull);
         expect(result!.value, equals(updatedValue));
       });
@@ -57,19 +48,15 @@ void main() {
       test(
           'Given an empty trie, '
           'when a new parameterized path is added with addOrUpdate, '
-          'then the path is added, lookup returns the value with parameters, and addOrUpdate returns false',
-          () {
-        // GIVEN: an empty trie and a parameterized path
+          'then the path is added', () {
         final pathDefinition = NormalizedPath('/users/:id');
         final lookupPath = NormalizedPath('/users/123');
         const value = 1;
 
-        // WHEN: addOrUpdate is called
-        final wasUpdated = trie.addOrUpdate(pathDefinition, value);
+        final wasAdded = trie.addOrUpdate(pathDefinition, value);
 
-        // THEN: the path is added and correct results are returned
         final result = trie.lookup(lookupPath);
-        expect(wasUpdated, isFalse);
+        expect(wasAdded, isTrue);
         expect(result, isNotNull);
         expect(result!.value, equals(value));
         expect(result.parameters, equals({#id: '123'}));
@@ -78,21 +65,17 @@ void main() {
       test(
           'Given a trie with an existing parameterized path, '
           'when addOrUpdate is called for that path with a new value, '
-          'then the value is updated, lookup returns new value with parameters, and addOrUpdate returns true',
-          () {
-        // GIVEN: a trie with an existing parameterized path
+          'then the value is updated', () {
         final pathDefinition = NormalizedPath('/users/:id');
         final lookupPath = NormalizedPath('/users/123');
         const initialValue = 1;
         const updatedValue = 2;
         trie.add(pathDefinition, initialValue);
 
-        // WHEN: addOrUpdate is called
-        final wasUpdated = trie.addOrUpdate(pathDefinition, updatedValue);
+        final wasAdded = trie.addOrUpdate(pathDefinition, updatedValue);
 
-        // THEN: the value is updated and correct results are returned
         final result = trie.lookup(lookupPath);
-        expect(wasUpdated, isTrue);
+        expect(wasAdded, isFalse);
         expect(result, isNotNull);
         expect(result!.value, equals(updatedValue));
         expect(result.parameters, equals({#id: '123'}));
@@ -103,16 +86,13 @@ void main() {
           'when addOrUpdate is called for /a/b, '
           'then /a/b is added with its value, /a retains its value, and both are retrievable',
           () {
-        // GIVEN: a trie with /a having a value
         final pathA = NormalizedPath('/a');
         final pathAB = NormalizedPath('/a/b');
         trie.addOrUpdate(pathA, 1);
 
-        // WHEN: addOrUpdate is called for /a/b
-        final wasUpdatedAB = trie.addOrUpdate(pathAB, 2);
+        final wasAddedAB = trie.addOrUpdate(pathAB, 2);
 
-        // THEN: /a/b is added, /a remains, both values are correct
-        expect(wasUpdatedAB, isFalse);
+        expect(wasAddedAB, isTrue);
         expect(trie.lookup(pathA)?.value, 1);
         expect(trie.lookup(pathAB)?.value, 2);
       });
@@ -120,18 +100,14 @@ void main() {
       test(
           'Given a trie with a path /a/b/c (making /a/b an intermediate node), '
           'when addOrUpdate is called for /a/b to give it a value, '
-          'then /a/b gets the value, /a/b/c remains accessible, and addOrUpdate for /a/b returns false (added value to existing node)',
-          () {
-        // GIVEN: /a/b/c exists, /a/b is intermediate without its own value
+          'then /a/b gets the value, /a/b/c remains accessible', () {
         final pathABC = NormalizedPath('/a/b/c');
         final pathAB = NormalizedPath('/a/b');
         trie.addOrUpdate(pathABC, 1); // /a/b is created as an intermediate node
 
-        // WHEN: addOrUpdate is called for /a/b
-        final wasUpdatedAB = trie.addOrUpdate(pathAB, 2);
+        final wasAddedAB = trie.addOrUpdate(pathAB, 2);
 
-        // THEN: /a/b now has a value, /a/b/c is still there
-        expect(wasUpdatedAB, isFalse,
+        expect(wasAddedAB, isTrue,
             reason:
                 "/a/b didn't have a value, so it's an addition of value, not an update of existing value.");
         expect(trie.lookup(pathAB)?.value, 2);
@@ -144,14 +120,11 @@ void main() {
           'Given a trie with an existing path and value, '
           'when update is called with that path and a new value, '
           'then lookup returns the new value', () {
-        // GIVEN: a path with a value
         final path = NormalizedPath('/posts');
         trie.add(path, 1);
 
-        // WHEN: update is called
         trie.update(path, 2);
 
-        // THEN: the value is updated
         final result = trie.lookup(path);
         expect(result, isNotNull);
         expect(result!.value, equals(2));
@@ -161,10 +134,8 @@ void main() {
           'Given a trie, '
           'when update is called for a path that does not exist, '
           'then an ArgumentError is thrown', () {
-        // GIVEN: a path that doesn't exist
         final path = NormalizedPath('/nonexistent');
 
-        // WHEN/THEN: update is called and throws
         expect(() => trie.update(path, 1), throwsArgumentError);
         expect(trie.lookup(path), isNull,
             reason: 'Path should not have been added.');
@@ -174,11 +145,9 @@ void main() {
           'Given a trie with /a/b (making /a intermediate and valueless), '
           'when update is called for /a, '
           'then an ArgumentError is thrown', () {
-        // GIVEN: /a is an intermediate node without a value
         trie.add(NormalizedPath('/a/b'), 2);
         final pathA = NormalizedPath('/a');
 
-        // WHEN/THEN: update is called for /a and throws
         expect(() => trie.update(pathA, 1), throwsArgumentError,
             reason:
                 "Cannot update a node that doesn't have an explicit value.");
@@ -192,14 +161,11 @@ void main() {
           'Given a trie with an existing parameterized path and value, '
           'when update is called with that path and a new value, '
           'then lookup returns the new value', () {
-        // GIVEN: a parameterized path with a value
         final pathDefinition = NormalizedPath('/posts/:id');
         trie.add(pathDefinition, 1);
 
-        // WHEN: update is called
         trie.update(pathDefinition, 2);
 
-        // THEN: the value is updated for the parameterized path
         final result = trie.lookup(NormalizedPath('/posts/abc'));
         expect(result, isNotNull);
         expect(result!.value, equals(2));
@@ -210,10 +176,8 @@ void main() {
           'Given a trie, '
           'when update is called for a parameterized path that does not exist as a defined route, '
           'then an ArgumentError is thrown', () {
-        // GIVEN: a parameterized path that hasn't been added
         final pathDefinition = NormalizedPath('/articles/:id');
 
-        // WHEN/THEN: update is called and throws
         expect(() => trie.update(pathDefinition, 1), throwsArgumentError);
         expect(trie.lookup(NormalizedPath('/articles/any')), isNull);
       });
@@ -225,14 +189,11 @@ void main() {
           'when remove is called, '
           'then it returns the removed value and lookup for that path returns null',
           () {
-        // GIVEN: a path with a value
         final path = NormalizedPath('/comments');
         trie.add(path, 1);
 
-        // WHEN: remove is called
         final removedValue = trie.remove(path);
 
-        // THEN: value is removed and correct value returned
         expect(removedValue, equals(1));
         expect(trie.lookup(path), isNull);
       });
@@ -241,14 +202,11 @@ void main() {
           'Given a trie, '
           'when remove is called for a path that does not exist, '
           'then it returns null and the trie is unchanged', () {
-        // GIVEN: a path that doesn't exist
         final path = NormalizedPath('/comments/123');
         trie.add(NormalizedPath('/other'), 1); // Ensure trie is not empty
 
-        // WHEN: remove is called for non-existent path
         final removedValue = trie.remove(path);
 
-        // THEN: null is returned, other paths unaffected
         expect(removedValue, isNull);
         expect(trie.lookup(path), isNull);
         expect(trie.lookup(NormalizedPath('/other'))?.value, 1);
@@ -258,15 +216,12 @@ void main() {
           'Given a trie with /a/b (making /a intermediate and valueless), '
           'when remove is called for /a, '
           'then it returns null and /a/b is still accessible', () {
-        // GIVEN: /a is intermediate and valueless, /a/b has a value
         final pathA = NormalizedPath('/a');
         final pathAB = NormalizedPath('/a/b');
         trie.add(pathAB, 2);
 
-        // WHEN: remove is called for /a
         final removedValue = trie.remove(pathA);
 
-        // THEN: null is returned, /a/b remains
         expect(removedValue, isNull, reason: '/a had no value to remove.');
         expect(trie.lookup(pathA), isNull);
         expect(trie.lookup(pathAB)?.value, 2);
@@ -277,16 +232,13 @@ void main() {
           'when remove is called for /parent, '
           'then /parent value is removed (returns value), lookup is null, but /parent/child is still accessible',
           () {
-        // GIVEN: parent and child both have values
         final parentPath = NormalizedPath('/articles');
         final childPath = NormalizedPath('/articles/details');
         trie.add(parentPath, 1);
         trie.add(childPath, 2);
 
-        // WHEN: remove is called for the parent path
         final removedValue = trie.remove(parentPath);
 
-        // THEN: parent's value is removed, child remains
         expect(removedValue, equals(1));
         expect(trie.lookup(parentPath), isNull,
             reason: 'Value of /articles should be removed.');
@@ -299,15 +251,12 @@ void main() {
           'when remove is called, '
           'then it returns the removed value and lookup for that parameterized path returns null',
           () {
-        // GIVEN: a parameterized path with a value
         final pathDefinition = NormalizedPath('/users/:id/settings');
         trie.add(pathDefinition, 1);
         trie.add(NormalizedPath('/users/data'), 2); // Sibling path
 
-        // WHEN: remove is called for the parameterized path definition
         final removedValue = trie.remove(pathDefinition);
 
-        // THEN: value is removed, path no longer matches
         expect(removedValue, equals(1));
         expect(trie.lookup(NormalizedPath('/users/123/settings')), isNull);
         expect(trie.lookup(NormalizedPath('/users/any/settings')), isNull);
@@ -320,16 +269,13 @@ void main() {
           'when remove is called for /, '
           'then / value is removed (returns value), but /a is still accessible',
           () {
-        // GIVEN: root and child have values
         final rootPath = NormalizedPath('/');
         final childPath = NormalizedPath('/a');
         trie.add(rootPath, 1);
         trie.add(childPath, 2);
 
-        // WHEN: remove is called for the root path
         final removedValue = trie.remove(rootPath);
 
-        // THEN: root value is removed, child remains
         expect(removedValue, equals(1));
         expect(trie.lookup(rootPath), isNull);
         expect(trie.lookup(childPath)?.value, 2);
@@ -339,14 +285,11 @@ void main() {
           'Given a trie with only root path / having a value, '
           'when remove is called for /, '
           'then / value is removed (returns value) and lookup is null', () {
-        // GIVEN: only root has a value
         final rootPath = NormalizedPath('/');
         trie.add(rootPath, 1);
 
-        // WHEN: remove is called for the root path
         final removedValue = trie.remove(rootPath);
 
-        // THEN: root value is removed
         expect(removedValue, equals(1));
         expect(trie.lookup(rootPath), isNull);
       });
@@ -356,7 +299,6 @@ void main() {
           'when /a/b/c is removed, '
           'then /a/b/d should still be accessible and /a/b (intermediate node) should not be affected.',
           () {
-        // GIVEN: two sibling paths sharing a common prefix
         final pathABC = NormalizedPath('/a/b/c');
         final pathABD = NormalizedPath('/a/b/d');
         trie.add(pathABC, 1);
@@ -364,16 +306,13 @@ void main() {
         // Optionally give /a/b a value to test its persistence
         trie.addOrUpdate(NormalizedPath('/a/b'), 3);
 
-        // WHEN: one of the sibling paths is removed
         final removedValue = trie.remove(pathABC);
 
-        // THEN: the removed path is gone, the other remains, intermediate nodes unchanged
         expect(removedValue, equals(1));
         expect(trie.lookup(pathABC), isNull);
         expect(trie.lookup(pathABD)?.value, 2);
         expect(trie.lookup(NormalizedPath('/a/b'))?.value, 3,
-            reason:
-                'Intermediate node /a/b should retain its value if it had one.');
+            reason: 'Intermediate node /a/b should retain its value.');
       });
     });
   });

--- a/test/router/path_trie_crud_test.dart
+++ b/test/router/path_trie_crud_test.dart
@@ -14,8 +14,7 @@ void main() {
       test(
           'Given an empty trie, '
           'when a new path is added with addOrUpdate, '
-          'then the path is added, lookup returns the value, and addOrUpdate returns true (added)',
-          () {
+          'then the path is added', () {
         final path = NormalizedPath('/users');
         const value = 1;
 
@@ -84,8 +83,7 @@ void main() {
       test(
           'Given a trie with a path /a (with a value), '
           'when addOrUpdate is called for /a/b, '
-          'then /a/b is added with its value, /a retains its value, and both are retrievable',
-          () {
+          'then both are retrievable', () {
         final pathA = NormalizedPath('/a');
         final pathAB = NormalizedPath('/a/b');
         trie.addOrUpdate(pathA, 1);
@@ -100,16 +98,14 @@ void main() {
       test(
           'Given a trie with a path /a/b/c (making /a/b an intermediate node), '
           'when addOrUpdate is called for /a/b to give it a value, '
-          'then /a/b gets the value, /a/b/c remains accessible', () {
+          'then both are retrievable', () {
         final pathABC = NormalizedPath('/a/b/c');
         final pathAB = NormalizedPath('/a/b');
         trie.addOrUpdate(pathABC, 1); // /a/b is created as an intermediate node
 
         final wasAddedAB = trie.addOrUpdate(pathAB, 2);
 
-        expect(wasAddedAB, isTrue,
-            reason:
-                "/a/b didn't have a value, so it's an addition of value, not an update of existing value.");
+        expect(wasAddedAB, isTrue);
         expect(trie.lookup(pathAB)?.value, 2);
         expect(trie.lookup(pathABC)?.value, 1);
       });
@@ -148,9 +144,7 @@ void main() {
         trie.add(NormalizedPath('/a/b'), 2);
         final pathA = NormalizedPath('/a');
 
-        expect(() => trie.update(pathA, 1), throwsArgumentError,
-            reason:
-                "Cannot update a node that doesn't have an explicit value.");
+        expect(() => trie.update(pathA, 1), throwsArgumentError);
         expect(trie.lookup(pathA), isNull,
             reason: '/a should not have gained a value.');
         expect(trie.lookup(NormalizedPath('/a/b'))?.value, 2,
@@ -187,8 +181,7 @@ void main() {
       test(
           'Given a trie with an existing leaf path and value, '
           'when remove is called, '
-          'then it returns the removed value and lookup for that path returns null',
-          () {
+          'then the value returned is removed', () {
         final path = NormalizedPath('/comments');
         trie.add(path, 1);
 
@@ -201,7 +194,7 @@ void main() {
       test(
           'Given a trie, '
           'when remove is called for a path that does not exist, '
-          'then it returns null and the trie is unchanged', () {
+          'then nothing is removed', () {
         final path = NormalizedPath('/comments/123');
         trie.add(NormalizedPath('/other'), 1); // Ensure trie is not empty
 
@@ -215,7 +208,7 @@ void main() {
       test(
           'Given a trie with /a/b (making /a intermediate and valueless), '
           'when remove is called for /a, '
-          'then it returns null and /a/b is still accessible', () {
+          'then nothing is removed', () {
         final pathA = NormalizedPath('/a');
         final pathAB = NormalizedPath('/a/b');
         trie.add(pathAB, 2);
@@ -230,7 +223,7 @@ void main() {
       test(
           'Given a trie with /parent (value) and /parent/child (value), '
           'when remove is called for /parent, '
-          'then /parent value is removed (returns value), lookup is null, but /parent/child is still accessible',
+          'then /parent value is removed, but /parent/child is still accessible',
           () {
         final parentPath = NormalizedPath('/articles');
         final childPath = NormalizedPath('/articles/details');
@@ -249,8 +242,7 @@ void main() {
       test(
           'Given a trie with a parameterized path and value, '
           'when remove is called, '
-          'then it returns the removed value and lookup for that parameterized path returns null',
-          () {
+          'then it returns the removed value', () {
         final pathDefinition = NormalizedPath('/users/:id/settings');
         trie.add(pathDefinition, 1);
         trie.add(NormalizedPath('/users/data'), 2); // Sibling path
@@ -267,8 +259,7 @@ void main() {
       test(
           'Given a trie with root path / (value) and child /a (value), '
           'when remove is called for /, '
-          'then / value is removed (returns value), but /a is still accessible',
-          () {
+          'then / value is removed, but /a is still accessible', () {
         final rootPath = NormalizedPath('/');
         final childPath = NormalizedPath('/a');
         trie.add(rootPath, 1);
@@ -284,7 +275,7 @@ void main() {
       test(
           'Given a trie with only root path / having a value, '
           'when remove is called for /, '
-          'then / value is removed (returns value) and lookup is null', () {
+          'then / value is removed', () {
         final rootPath = NormalizedPath('/');
         trie.add(rootPath, 1);
 
@@ -297,22 +288,17 @@ void main() {
       test(
           'Given a trie with /a/b/c and /a/b/d, '
           'when /a/b/c is removed, '
-          'then /a/b/d should still be accessible and /a/b (intermediate node) should not be affected.',
-          () {
+          'then /a/b/d should still be accessible.', () {
         final pathABC = NormalizedPath('/a/b/c');
         final pathABD = NormalizedPath('/a/b/d');
         trie.add(pathABC, 1);
         trie.add(pathABD, 2);
-        // Optionally give /a/b a value to test its persistence
-        trie.addOrUpdate(NormalizedPath('/a/b'), 3);
 
         final removedValue = trie.remove(pathABC);
 
         expect(removedValue, equals(1));
         expect(trie.lookup(pathABC), isNull);
         expect(trie.lookup(pathABD)?.value, 2);
-        expect(trie.lookup(NormalizedPath('/a/b'))?.value, 3,
-            reason: 'Intermediate node /a/b should retain its value.');
       });
     });
   });


### PR DESCRIPTION
## Description
Add missing CRUD operations to `PathTrie`:
- `addOrUpdate`
- `update`, and
- `remove`

## Related Issues
- Closes: ?

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code usixg [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced route management with new methods to add, update, or remove routes in the routing system.

- **Documentation**
  - Improved documentation for error conditions when attaching routes.

- **Tests**
  - Added comprehensive tests for adding, updating, and removing routes, including handling of parameterized paths and various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->