### PR TITLE
feat: Router middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package was born out of the needs of [Serverpod](https://serverpod.dev), as
 - We made everything type-safe (no more dynamic).
 - Encoding types have been moved to the `Body` of a `Request`/`Response` to simplify the logic when syncing up the headers and to have a single source of truth.
 - We've added parsers and validation for all commonly used HTTP headers. E.g., times are represented by `DateTime`, cookies have their own class with validation of formatting, etc.
-- Routing has been implemented using a `PathTrie` structure for efficient route matching and parameter extraction.
+- Routing has been implemented using a [trie](https://en.wikipedia.org/wiki/Trie) data-structure (`PathTrie`) for efficient route matching and parameter extraction.
 - Extended test coverage.
 - There are lots of smaller fixes here and there.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package was born out of the needs of [Serverpod](https://serverpod.dev), as
 - We made everything type-safe (no more dynamic).
 - Encoding types have been moved to the `Body` of a `Request`/`Response` to simplify the logic when syncing up the headers and to have a single source of truth.
 - We've added parsers and validation for all commonly used HTTP headers. E.g., times are represented by `DateTime`, cookies have their own class with validation of formatting, etc.
+- Routing has been implemented using a `PathTrie` structure for efficient route matching and parameter extraction.
 - Extended test coverage.
 - There are lots of smaller fixes here and there.
 
@@ -25,7 +26,6 @@ Although the structure is very similar to Shelf, this is no longer backward comp
 
 Before a stable release, we're also planning on adding the following features:
 - We want to more tightly integrate a http server (i.e., start with `HttpServer` from `dart:io` as a base) with Relic so that everything uses the same types. This will also improve performance as fewer conversions will be needed.
-- Routing can be improved by using Radix trees. Currently, there is just a list being traversed, which can be an issue if you have many routes.
 - We're planning to add an improved testing framework.
 - Performance testing and optimizations.
 
@@ -33,33 +33,45 @@ In addition, we're planning to include Relic in [Serverpod](https://serverpod.de
 
 ## Example
 
-See `example/example.dart`
+See `relic/example/example.dart` for a runnable example. The following code demonstrates basic routing and request handling:
 
 ```dart
+import 'dart:io';
+
 import 'package:relic/relic.dart';
+import 'package:relic/src/adapter/context.dart';
+import 'package:relic/src/middleware/routing_middleware.dart';
 
-void main() async {
-  var handler =
-      const Pipeline().addMiddleware(logRequests()).addHandler(_echoRequest);
+/// A simple 'Hello World' server
+Future<void> main() async {
+  // Setup router
+  final router = Router<Handler>()..get('/user/:name/age/:age', hello);
 
-  var server = await serve(
-    handler,
-    RelicAddress.fromHostname('localhost'),
-    8080,
-  );
+  // Setup a handler.
+  //
+  // A [Handler] is function consuming and producing [RequestContext]s,
+  // but if you are mostly concerned with converting [Request]s to [Response]s
+  // (known as a [Responder] in relic parlor) you can use [respondWith] to
+  // wrap a [Responder] into a [Handler]
+  final handler = const Pipeline()
+      .addMiddleware(logRequests())
+      .addMiddleware(routeWith(router))
+      .addHandler(respondWith((final _) => Response.notFound(
+          body: Body.fromString("Sorry, that doesn't compute"))));
 
-  // Enable content compression
-  server.autoCompress = true;
+  // Start the server with the handler
+  await serve(handler, InternetAddress.anyIPv4, 8080);
 
-  print('Serving at http://${server.address.host}:${server.port}');
+  print('Serving at http://localhost:8080');
+  // Check the _example_ directory for other examples.
 }
 
-Response _echoRequest(Request request) {
-  return Response.ok(
-    body: Body.fromString(
-      'Request for "${request.url}"',
-    ),
-  );
+ResponseContext hello(final RequestContext ctx) {
+  final name = ctx.pathParameters[#name];
+  final age = int.parse(ctx.pathParameters[#age]!);
+
+  return (ctx as RespondableContext).withResponse(Response.ok(
+      body: Body.fromString('Hello $name! To think you are $age years old.')));
 }
 ```
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,16 +1,25 @@
 import 'dart:io';
 
 import 'package:relic/relic.dart';
+import 'package:relic/src/adapter/context.dart';
+import 'package:relic/src/middleware/routing_middleware.dart';
 
 /// A simple 'Hello World' server
 Future<void> main() async {
+  // Setup router
+  final router = Router<Handler>()..get('/user/:name/age/:age', hello);
+
   // Setup a handler.
   //
   // A [Handler] is function consuming and producing [RequestContext]s,
   // but if you are mostly concerned with converting [Request]s to [Response]s
   // (known as a [Responder] in relic parlor) you can use [respondWith] to
   // wrap a [Responder] into a [Handler]
-  final handler = respondWith(hello);
+  final handler = const Pipeline()
+      .addMiddleware(logRequests())
+      .addMiddleware(routeWith(router))
+      .addHandler(respondWith((final _) => Response.notFound(
+          body: Body.fromString("Sorry, that doesn't compute"))));
 
   // Start the server with the handler
   await serve(handler, InternetAddress.anyIPv4, 8080);
@@ -18,6 +27,10 @@ Future<void> main() async {
   // Check the _example_ directory for other examples.
 }
 
-/// A very simple [Responder].
-Response hello(final Request request) =>
-    Response.ok(body: Body.fromString('Hello World'));
+ResponseContext hello(final RequestContext ctx) {
+  final name = ctx.pathParameters[#name];
+  final age = int.parse(ctx.pathParameters[#age]!);
+
+  return (ctx as RespondableContext).withResponse(Response.ok(
+      body: Body.fromString('Hello $name! To think you are $age years old.')));
+}

--- a/lib/src/middleware/routing_middleware.dart
+++ b/lib/src/middleware/routing_middleware.dart
@@ -1,0 +1,57 @@
+import '../adapter/context.dart';
+import '../handler/handler.dart';
+import '../method/request_method.dart';
+import '../router/router.dart';
+import 'middleware.dart';
+
+Middleware routeWith(final Router<Handler> router) =>
+    RoutingMiddleware(router).meddle;
+
+final _pathParametersStorage = Expando<Map<Symbol, String>>();
+
+class RoutingMiddleware {
+  final Router<Handler> _router;
+
+  RoutingMiddleware(this._router);
+
+  Handler meddle(final Handler next) {
+    return (final ctx) async {
+      final req = ctx.request;
+      final url = ctx.request.url; // TODO: Use requestUri
+      final match = _router.lookup(req.method.convert(), url.path);
+      if (match != null) {
+        ctx._pathParameters = match.parameters;
+        final handler = match.value;
+        return await handler(ctx);
+      } else {
+        return await next(ctx);
+      }
+    };
+  }
+}
+
+extension RequestContextEx on RequestContext {
+  Map<Symbol, String> get pathParameters =>
+      _pathParametersStorage[token] ??
+      (throw StateError('Add RoutingMiddleware!'));
+
+  set _pathParameters(final Map<Symbol, String> value) =>
+      _pathParametersStorage[token] = value;
+}
+
+extension on RequestMethod {
+  Method convert() {
+    return switch (this) {
+      RequestMethod.get => Method.get,
+      RequestMethod.post => Method.post,
+      RequestMethod.put => Method.put,
+      RequestMethod.delete => Method.delete,
+      RequestMethod.head => Method.head,
+      RequestMethod.options => Method.options,
+      RequestMethod.patch => Method.patch,
+      RequestMethod.trace => Method.trace,
+      RequestMethod.connect => Method.connect,
+      _ => throw UnimplementedError(),
+    };
+  }
+}

--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -94,7 +94,7 @@ class RelicServer {
 
     try {
       final ctx = request
-          .toContext(adapterRequest); // adaptor request will be the token
+          .toContext(adapterRequest); // adapter request will be the token
       final newCtx = await handler(ctx);
       return switch (newCtx) {
         final ResponseContext rc =>

--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -93,7 +93,8 @@ class RelicServer {
     }
 
     try {
-      final ctx = request.toContext();
+      final ctx = request
+          .toContext(adapterRequest); // adaptor request will be the token
       final newCtx = await handler(ctx);
       return switch (newCtx) {
         final ResponseContext rc =>

--- a/test/middleware/routing_middleware_test.dart
+++ b/test/middleware/routing_middleware_test.dart
@@ -1,0 +1,423 @@
+import 'package:relic/relic.dart';
+import 'package:relic/src/adapter/context.dart';
+import 'package:relic/src/method/request_method.dart' as relic_req_method;
+import 'package:relic/src/middleware/routing_middleware.dart';
+import 'package:test/test.dart';
+
+// Simple fake implementations for testing
+class FakeRequest implements Request {
+  @override
+  final Uri url;
+  @override
+  final relic_req_method.RequestMethod method;
+
+  @override
+  dynamic noSuchMethod(final Invocation invocation) {
+    throw UnimplementedError(invocation.memberName.toString());
+  }
+
+  FakeRequest(final String path,
+      {this.method = relic_req_method.RequestMethod.get})
+      : url = Uri.parse('http://localhost$path');
+}
+
+class FakeResponse implements Response {
+  @override
+  final int statusCode;
+  final Map<Symbol, String>? parameters;
+
+  FakeResponse(this.statusCode, {this.parameters});
+
+  @override
+  dynamic noSuchMethod(final Invocation invocation) {
+    throw UnimplementedError(invocation.memberName.toString());
+  }
+}
+
+void main() {
+  group('RoutingMiddleware', () {
+    late Router<Handler> router;
+    late RoutingMiddleware middleware;
+
+    setUp(() {
+      router = Router<Handler>();
+      middleware = RoutingMiddleware(router);
+    });
+
+    group('Parameter Propagation', () {
+      test(
+          'Given a router with a parameterized route and RoutingMiddleware, '
+          'When a request matches the parameterized route, '
+          'Then the handler receives correct path parameters', () async {
+        Map<Symbol, String>? capturedParams;
+        Future<ResponseContext> testHandler(final RequestContext ctx) async {
+          capturedParams = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(200, parameters: capturedParams));
+        }
+
+        router.add(Method.get, '/users/:id', testHandler);
+
+        final initialCtx = FakeRequest('/users/123').toContext(Object());
+        final resultingCtx =
+            await middleware.meddle((final RequestContext ctx) async {
+          return (ctx as RespondableContext).withResponse(FakeResponse(404));
+        })(initialCtx);
+
+        expect(capturedParams, isNotNull);
+        expect(capturedParams, equals({#id: '123'}));
+        expect(resultingCtx, isA<ResponseContext>());
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+        expect(response.statusCode, equals(200));
+        expect(response.parameters, equals({#id: '123'}));
+      });
+
+      test(
+          'Given a router with a non-parameterized route and RoutingMiddleware, '
+          'When a request matches the non-parameterized route, '
+          'Then the handler receives empty path parameters', () async {
+        Map<Symbol, String>? capturedParams;
+        Future<ResponseContext> testHandler(final RequestContext ctx) async {
+          capturedParams = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(200, parameters: capturedParams));
+        }
+
+        router.add(Method.get, '/users', testHandler);
+
+        final initialCtx = FakeRequest('/users').toContext(Object());
+        final resultingCtx =
+            await middleware.meddle((final RequestContext ctx) async {
+          return (ctx as RespondableContext).withResponse(FakeResponse(404));
+        })(initialCtx);
+
+        expect(capturedParams, isNotNull);
+        expect(capturedParams, isEmpty);
+        expect(resultingCtx, isA<ResponseContext>());
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+        expect(response.statusCode, equals(200));
+        expect(response.parameters, isEmpty);
+      });
+
+      test(
+          'Given RoutingMiddleware and a request that does not match any route, '
+          'When the middleware processes the request, '
+          'Then the next handler is called and pathParameters access throws StateError',
+          () async {
+        bool nextCalled = false;
+        Future<ResponseContext> nextHandler(final RequestContext ctx) async {
+          nextCalled = true;
+          expect(() => ctx.pathParameters, throwsStateError);
+          return (ctx as RespondableContext).withResponse(FakeResponse(404));
+        }
+
+        final initialCtx = FakeRequest('/nonexistent').toContext(Object());
+        final resultingCtx = await middleware.meddle(nextHandler)(initialCtx);
+
+        expect(nextCalled, isTrue);
+        expect(resultingCtx, isA<ResponseContext>());
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+        expect(response.statusCode, equals(404));
+      });
+    });
+
+    group('Multiple RoutingMiddleware in Pipeline', () {
+      late Router<Handler> router1;
+      late RoutingMiddleware middleware1;
+      late Router<Handler> router2;
+      late RoutingMiddleware middleware2;
+
+      setUp(() {
+        router1 = Router<Handler>();
+        middleware1 = RoutingMiddleware(router1);
+        router2 = Router<Handler>();
+        middleware2 = RoutingMiddleware(router2);
+      });
+
+      test(
+          'Given two RoutingMiddleware instances in a pipeline, '
+          'When a request matches a route in the first router, '
+          'Then the handler from the first router is executed with correct parameters',
+          () async {
+        Map<Symbol, String>? params1;
+        bool handler1Called = false;
+        bool handler2Called = false;
+
+        router1.add(Method.get, '/router1/:item',
+            (final RequestContext ctx) async {
+          handler1Called = true;
+          params1 = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(201, parameters: params1));
+        });
+        router2.add(Method.get, '/router2/:item',
+            (final RequestContext ctx) async {
+          handler2Called = true;
+          return (ctx as RespondableContext).withResponse(FakeResponse(202));
+        });
+
+        final pipeline = middleware1.meddle(middleware2.meddle(
+            (final RequestContext ctx) async =>
+                (ctx as RespondableContext).withResponse(FakeResponse(404))));
+
+        final initialCtx = FakeRequest('/router1/apple').toContext(Object());
+        final resultingCtx = await pipeline(initialCtx);
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+
+        expect(handler1Called, isTrue);
+        expect(handler2Called, isFalse);
+        expect(response.statusCode, equals(201));
+        expect(params1, equals({#item: 'apple'}));
+        expect(response.parameters, equals({#item: 'apple'}));
+      });
+
+      test(
+          'Given two RoutingMiddleware instances in a pipeline, '
+          'When a request matches a route in the second router (but not the first), '
+          'Then the handler from the second router is executed with correct parameters',
+          () async {
+        Map<Symbol, String>? params2;
+        bool handler1Called = false;
+        bool handler2Called = false;
+
+        router1.add(Method.get, '/router1/:item',
+            (final RequestContext ctx) async {
+          handler1Called = true;
+          return (ctx as RespondableContext).withResponse(FakeResponse(201));
+        });
+        router2.add(Method.get, '/router2/:data',
+            (final RequestContext ctx) async {
+          handler2Called = true;
+          params2 = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(202, parameters: params2));
+        });
+
+        final pipeline = middleware1.meddle(middleware2.meddle(
+            (final RequestContext ctx) async =>
+                (ctx as RespondableContext).withResponse(FakeResponse(404))));
+
+        final initialCtx = FakeRequest('/router2/banana').toContext(Object());
+        final resultingCtx = await pipeline(initialCtx);
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+
+        expect(handler1Called, isFalse);
+        expect(handler2Called, isTrue);
+        expect(response.statusCode, equals(202));
+        expect(params2, equals({#data: 'banana'}));
+        expect(response.parameters, equals({#data: 'banana'}));
+      });
+
+      test(
+          'Given two RoutingMiddleware instances in a pipeline, '
+          'When a request does not match any route in either router, '
+          'Then the final next handler is called', () async {
+        bool handler1Called = false;
+        bool handler2Called = false;
+        bool fallbackCalled = false;
+
+        router1.add(Method.get, '/router1/:item',
+            (final RequestContext ctx) async {
+          handler1Called = true;
+          return (ctx as RespondableContext).withResponse(FakeResponse(201));
+        });
+        router2.add(Method.get, '/router2/:data',
+            (final RequestContext ctx) async {
+          handler2Called = true;
+          return (ctx as RespondableContext).withResponse(FakeResponse(202));
+        });
+
+        final pipeline = middleware1
+            .meddle(middleware2.meddle((final RequestContext ctx) async {
+          fallbackCalled = true;
+          return (ctx as RespondableContext).withResponse(FakeResponse(404));
+        }));
+
+        final initialCtx = FakeRequest('/neither/nor').toContext(Object());
+        final resultingCtx = await pipeline(initialCtx);
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+
+        expect(handler1Called, isFalse);
+        expect(handler2Called, isFalse);
+        expect(fallbackCalled, isTrue);
+        expect(response.statusCode, equals(404));
+      });
+    });
+
+    group('Nested RoutingMiddleware (via Router.attach)', () {
+      test(
+          'Given a main Router with a nested Router attached, and RoutingMiddleware for the main Router, '
+          'When a request matches a route within the nested Router, '
+          'Then the handler from the nested Router is executed with merged path parameters',
+          () async {
+        Map<Symbol, String>? capturedParams;
+        bool nestedHandlerCalled = false;
+
+        final mainRouter = Router<Handler>();
+        final nestedRouter = Router<Handler>();
+
+        nestedRouter.add(Method.get, '/details/:detailId',
+            (final RequestContext ctx) async {
+          nestedHandlerCalled = true;
+          capturedParams = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(200, parameters: capturedParams));
+        });
+
+        // Attach nestedRouter to mainRouter under /resource/:resourceId
+        mainRouter.attach('/resource/:resourceId', nestedRouter);
+
+        final mainMiddleware = RoutingMiddleware(mainRouter);
+        final pipeline = mainMiddleware.meddle(
+            (final RequestContext ctx) async =>
+                (ctx as RespondableContext).withResponse(FakeResponse(404)));
+
+        final initialCtx =
+            FakeRequest('/resource/abc/details/xyz').toContext(Object());
+        final resultingCtx = await pipeline(initialCtx);
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+
+        expect(nestedHandlerCalled, isTrue);
+        expect(response.statusCode, equals(200));
+        expect(capturedParams, isNotNull);
+        expect(capturedParams, equals({#resourceId: 'abc', #detailId: 'xyz'}));
+        expect(response.parameters,
+            equals({#resourceId: 'abc', #detailId: 'xyz'}));
+      });
+
+      test(
+          'Given a main Router with a nested Router (that itself has parameters at its root) attached, '
+          'When a request matches, '
+          'Then parameters from both levels are correctly captured', () async {
+        // This test addresses the user's note about potential errors in nested routing.
+        // The key is that Router.lookup should correctly merge parameters.
+        Map<Symbol, String>? capturedParams;
+        bool deeplyNestedHandlerCalled = false;
+
+        final mainRouter = Router<Handler>();
+        final intermediateRouter =
+            Router<Handler>(); // Will be attached to mainRouter
+        final leafRouter =
+            Router<Handler>(); // Will be attached to intermediateRouter
+
+        // Define handler for the leaf router
+        leafRouter.add(Method.get, '/action/:actionName',
+            (final RequestContext ctx) async {
+          deeplyNestedHandlerCalled = true;
+          capturedParams = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(200, parameters: capturedParams));
+        });
+
+        // Attach leafRouter to intermediateRouter under a parameterized path
+        intermediateRouter.attach('/:intermediateId', leafRouter);
+
+        // Attach intermediateRouter to mainRouter under a parameterized path
+        mainRouter.attach('/base/:baseId', intermediateRouter);
+
+        final mainMiddleware = RoutingMiddleware(mainRouter);
+        final pipeline = mainMiddleware.meddle(
+            (final RequestContext ctx) async =>
+                (ctx as RespondableContext).withResponse(FakeResponse(404)));
+
+        final initialCtx = FakeRequest('/base/b123/i456/action/doSomething')
+            .toContext(Object());
+        final resultingCtx = await pipeline(initialCtx);
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+
+        expect(deeplyNestedHandlerCalled, isTrue);
+        expect(response.statusCode, equals(200));
+        expect(capturedParams, isNotNull);
+        expect(
+            capturedParams,
+            equals({
+              #baseId: 'b123',
+              #intermediateId: 'i456',
+              #actionName: 'doSomething'
+            }));
+        expect(
+            response.parameters,
+            equals({
+              #baseId: 'b123',
+              #intermediateId: 'i456',
+              #actionName: 'doSomething'
+            }));
+      });
+
+      test(
+          'Given a path with repeated parameters at different levels introduced by attach, '
+          'When looked up via RoutingMiddleware, '
+          'Then last extracted parameter wins (consistent with PathTrie behavior)',
+          () async {
+        Map<Symbol, String>? capturedParams;
+        final mainRouter = Router<Handler>();
+        final subRouter = Router<Handler>();
+
+        subRouter.add(Method.get, '/:id/end', (final RequestContext ctx) async {
+          // sub-router uses :id
+          capturedParams = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(200, parameters: capturedParams));
+        });
+
+        mainRouter.attach('/:id/sub', subRouter); // main router uses :id
+
+        final middleware = RoutingMiddleware(mainRouter);
+        final pipeline = middleware.meddle((final RequestContext ctx) async =>
+            (ctx as RespondableContext).withResponse(FakeResponse(404)));
+
+        final initialCtx = FakeRequest('/123/sub/456/end').toContext(Object());
+        final resultingCtx = await pipeline(initialCtx);
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+
+        expect(response.statusCode, 200);
+        expect(capturedParams, isNotNull);
+        // PathTrie's behavior is that the parameter from the deeper segment wins.
+        // Full path: /:id/sub/:id/end -> /123/sub/456/end
+        // Parameters: {#id: '123', #id: '456'} -> {#id: '456'}
+        expect(capturedParams, equals({#id: '456'}));
+        expect(response.parameters, equals({#id: '456'}));
+      });
+    });
+
+    group('routeWith utility', () {
+      test(
+          'Given a router, When routeWith is used to create middleware, Then it functions like RoutingMiddleware',
+          () async {
+        Map<Symbol, String>? capturedParams;
+        Future<ResponseContext> testHandler(final RequestContext ctx) async {
+          capturedParams = ctx.pathParameters;
+          return (ctx as RespondableContext)
+              .withResponse(FakeResponse(200, parameters: capturedParams));
+        }
+
+        router.add(Method.get, '/utils/:param', testHandler);
+
+        final middlewareFunc = routeWith(router);
+        final handlerChain = middlewareFunc((final RequestContext ctx) async {
+          return (ctx as RespondableContext).withResponse(FakeResponse(404));
+        });
+
+        final initialCtx = FakeRequest('/utils/testValue').toContext(Object());
+        final resultingCtx = await handlerChain(initialCtx);
+
+        expect(capturedParams, isNotNull);
+        expect(capturedParams, equals({#param: 'testValue'}));
+        expect(resultingCtx, isA<ResponseContext>());
+        final response =
+            (resultingCtx as ResponseContext).response as FakeResponse;
+        expect(response.statusCode, equals(200));
+        expect(response.parameters, equals({#param: 'testValue'}));
+      });
+    });
+  });
+}

--- a/test/middleware/routing_middleware_test.dart
+++ b/test/middleware/routing_middleware_test.dart
@@ -1,47 +1,36 @@
+import 'package:mockito/mockito.dart';
 import 'package:relic/relic.dart';
 import 'package:relic/src/adapter/context.dart';
-import 'package:relic/src/method/request_method.dart' as relic_req_method;
+import 'package:relic/src/method/request_method.dart';
 import 'package:relic/src/middleware/routing_middleware.dart';
 import 'package:test/test.dart';
 
 // Simple fake implementations for testing
-class FakeRequest implements Request {
+class _FakeRequest extends Fake implements Request {
   @override
   final Uri url;
   @override
-  final relic_req_method.RequestMethod method;
+  final RequestMethod method = RequestMethod.get;
 
-  @override
-  dynamic noSuchMethod(final Invocation invocation) {
-    throw UnimplementedError(invocation.memberName.toString());
-  }
-
-  FakeRequest(final String path,
-      {this.method = relic_req_method.RequestMethod.get})
-      : url = Uri.parse('http://localhost$path');
+  _FakeRequest(final String path) : url = Uri.parse('http://localhost$path');
 }
 
-class FakeResponse implements Response {
+class _FakeResponse extends Fake implements Response {
   @override
   final int statusCode;
   final Map<Symbol, String>? parameters;
 
-  FakeResponse(this.statusCode, {this.parameters});
-
-  @override
-  dynamic noSuchMethod(final Invocation invocation) {
-    throw UnimplementedError(invocation.memberName.toString());
-  }
+  _FakeResponse(this.statusCode, {this.parameters});
 }
 
 void main() {
   group('RoutingMiddleware', () {
     late Router<Handler> router;
-    late RoutingMiddleware middleware;
+    late Middleware middleware;
 
     setUp(() {
       router = Router<Handler>();
-      middleware = RoutingMiddleware(router);
+      middleware = routeWith(router);
     });
 
     group('Parameter Propagation', () {
@@ -53,22 +42,20 @@ void main() {
         Future<ResponseContext> testHandler(final RequestContext ctx) async {
           capturedParams = ctx.pathParameters;
           return (ctx as RespondableContext)
-              .withResponse(FakeResponse(200, parameters: capturedParams));
+              .withResponse(_FakeResponse(200, parameters: capturedParams));
         }
 
         router.add(Method.get, '/users/:id', testHandler);
 
-        final initialCtx = FakeRequest('/users/123').toContext(Object());
-        final resultingCtx =
-            await middleware.meddle((final RequestContext ctx) async {
-          return (ctx as RespondableContext).withResponse(FakeResponse(404));
-        })(initialCtx);
+        final initialCtx = _FakeRequest('/users/123').toContext(Object());
+        final resultingCtx = await middleware(
+            respondWith((final _) => _FakeResponse(404)))(initialCtx);
 
         expect(capturedParams, isNotNull);
         expect(capturedParams, equals({#id: '123'}));
         expect(resultingCtx, isA<ResponseContext>());
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
         expect(response.statusCode, equals(200));
         expect(response.parameters, equals({#id: '123'}));
       });
@@ -81,22 +68,20 @@ void main() {
         Future<ResponseContext> testHandler(final RequestContext ctx) async {
           capturedParams = ctx.pathParameters;
           return (ctx as RespondableContext)
-              .withResponse(FakeResponse(200, parameters: capturedParams));
+              .withResponse(_FakeResponse(200, parameters: capturedParams));
         }
 
         router.add(Method.get, '/users', testHandler);
 
-        final initialCtx = FakeRequest('/users').toContext(Object());
-        final resultingCtx =
-            await middleware.meddle((final RequestContext ctx) async {
-          return (ctx as RespondableContext).withResponse(FakeResponse(404));
-        })(initialCtx);
+        final initialCtx = _FakeRequest('/users').toContext(Object());
+        final resultingCtx = await middleware(
+            respondWith((final _) => _FakeResponse(404)))(initialCtx);
 
         expect(capturedParams, isNotNull);
         expect(capturedParams, isEmpty);
         expect(resultingCtx, isA<ResponseContext>());
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
         expect(response.statusCode, equals(200));
         expect(response.parameters, isEmpty);
       });
@@ -110,31 +95,32 @@ void main() {
         Future<ResponseContext> nextHandler(final RequestContext ctx) async {
           nextCalled = true;
           expect(() => ctx.pathParameters, throwsStateError);
-          return (ctx as RespondableContext).withResponse(FakeResponse(404));
+          return (ctx as RespondableContext).withResponse(_FakeResponse(404));
         }
 
-        final initialCtx = FakeRequest('/nonexistent').toContext(Object());
-        final resultingCtx = await middleware.meddle(nextHandler)(initialCtx);
+        final initialCtx = _FakeRequest('/nonexistent').toContext(Object());
+        final resultingCtx = await middleware(nextHandler)(initialCtx);
 
         expect(nextCalled, isTrue);
         expect(resultingCtx, isA<ResponseContext>());
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
         expect(response.statusCode, equals(404));
       });
     });
 
     group('Multiple RoutingMiddleware in Pipeline', () {
       late Router<Handler> router1;
-      late RoutingMiddleware middleware1;
       late Router<Handler> router2;
-      late RoutingMiddleware middleware2;
+      late Pipeline pipeline;
 
       setUp(() {
         router1 = Router<Handler>();
-        middleware1 = RoutingMiddleware(router1);
         router2 = Router<Handler>();
-        middleware2 = RoutingMiddleware(router2);
+        pipeline = const Pipeline()
+            .addMiddleware(routeWith(router1))
+            .addMiddleware(routeWith(router2));
+        // just missing the handler
       });
 
       test(
@@ -151,22 +137,20 @@ void main() {
           handler1Called = true;
           params1 = ctx.pathParameters;
           return (ctx as RespondableContext)
-              .withResponse(FakeResponse(201, parameters: params1));
+              .withResponse(_FakeResponse(201, parameters: params1));
         });
-        router2.add(Method.get, '/router2/:item',
-            (final RequestContext ctx) async {
+        router2.add(Method.get, '/router2/:item', respondWith((final _) {
           handler2Called = true;
-          return (ctx as RespondableContext).withResponse(FakeResponse(202));
-        });
+          return _FakeResponse(202);
+        }));
 
-        final pipeline = middleware1.meddle(middleware2.meddle(
-            (final RequestContext ctx) async =>
-                (ctx as RespondableContext).withResponse(FakeResponse(404))));
+        final pipelineHandler =
+            pipeline.addHandler(respondWith((final _) => _FakeResponse(404)));
 
-        final initialCtx = FakeRequest('/router1/apple').toContext(Object());
-        final resultingCtx = await pipeline(initialCtx);
+        final initialCtx = _FakeRequest('/router1/apple').toContext(Object());
+        final resultingCtx = await pipelineHandler(initialCtx);
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
 
         expect(handler1Called, isTrue);
         expect(handler2Called, isFalse);
@@ -184,27 +168,25 @@ void main() {
         bool handler1Called = false;
         bool handler2Called = false;
 
-        router1.add(Method.get, '/router1/:item',
-            (final RequestContext ctx) async {
+        router1.add(Method.get, '/router1/:item', respondWith((final _) {
           handler1Called = true;
-          return (ctx as RespondableContext).withResponse(FakeResponse(201));
-        });
+          return _FakeResponse(201);
+        }));
         router2.add(Method.get, '/router2/:data',
             (final RequestContext ctx) async {
           handler2Called = true;
           params2 = ctx.pathParameters;
           return (ctx as RespondableContext)
-              .withResponse(FakeResponse(202, parameters: params2));
+              .withResponse(_FakeResponse(202, parameters: params2));
         });
 
-        final pipeline = middleware1.meddle(middleware2.meddle(
-            (final RequestContext ctx) async =>
-                (ctx as RespondableContext).withResponse(FakeResponse(404))));
+        final pipelineHandler =
+            pipeline.addHandler(respondWith((final _) => _FakeResponse(404)));
 
-        final initialCtx = FakeRequest('/router2/banana').toContext(Object());
-        final resultingCtx = await pipeline(initialCtx);
+        final initialCtx = _FakeRequest('/router2/banana').toContext(Object());
+        final resultingCtx = await pipelineHandler(initialCtx);
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
 
         expect(handler1Called, isFalse);
         expect(handler2Called, isTrue);
@@ -221,27 +203,24 @@ void main() {
         bool handler2Called = false;
         bool fallbackCalled = false;
 
-        router1.add(Method.get, '/router1/:item',
-            (final RequestContext ctx) async {
+        router1.add(Method.get, '/router1/:item', respondWith((final _) {
           handler1Called = true;
-          return (ctx as RespondableContext).withResponse(FakeResponse(201));
-        });
-        router2.add(Method.get, '/router2/:data',
-            (final RequestContext ctx) async {
+          return _FakeResponse(201);
+        }));
+        router2.add(Method.get, '/router2/:data', respondWith((final _) {
           handler2Called = true;
-          return (ctx as RespondableContext).withResponse(FakeResponse(202));
-        });
-
-        final pipeline = middleware1
-            .meddle(middleware2.meddle((final RequestContext ctx) async {
-          fallbackCalled = true;
-          return (ctx as RespondableContext).withResponse(FakeResponse(404));
+          return _FakeResponse(202);
         }));
 
-        final initialCtx = FakeRequest('/neither/nor').toContext(Object());
-        final resultingCtx = await pipeline(initialCtx);
+        final pipelineHandler = pipeline.addHandler(respondWith((final _) {
+          fallbackCalled = true;
+          return _FakeResponse(404);
+        }));
+
+        final initialCtx = _FakeRequest('/neither/nor').toContext(Object());
+        final resultingCtx = await pipelineHandler(initialCtx);
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
 
         expect(handler1Called, isFalse);
         expect(handler2Called, isFalse);
@@ -267,22 +246,21 @@ void main() {
           nestedHandlerCalled = true;
           capturedParams = ctx.pathParameters;
           return (ctx as RespondableContext)
-              .withResponse(FakeResponse(200, parameters: capturedParams));
+              .withResponse(_FakeResponse(200, parameters: capturedParams));
         });
 
         // Attach nestedRouter to mainRouter under /resource/:resourceId
         mainRouter.attach('/resource/:resourceId', nestedRouter);
 
-        final mainMiddleware = RoutingMiddleware(mainRouter);
-        final pipeline = mainMiddleware.meddle(
-            (final RequestContext ctx) async =>
-                (ctx as RespondableContext).withResponse(FakeResponse(404)));
+        final pipelineHandler = const Pipeline()
+            .addMiddleware(routeWith(mainRouter))
+            .addHandler(respondWith((final _) => _FakeResponse(404)));
 
         final initialCtx =
-            FakeRequest('/resource/abc/details/xyz').toContext(Object());
-        final resultingCtx = await pipeline(initialCtx);
+            _FakeRequest('/resource/abc/details/xyz').toContext(Object());
+        final resultingCtx = await pipelineHandler(initialCtx);
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
 
         expect(nestedHandlerCalled, isTrue);
         expect(response.statusCode, equals(200));
@@ -313,7 +291,7 @@ void main() {
           deeplyNestedHandlerCalled = true;
           capturedParams = ctx.pathParameters;
           return (ctx as RespondableContext)
-              .withResponse(FakeResponse(200, parameters: capturedParams));
+              .withResponse(_FakeResponse(200, parameters: capturedParams));
         });
 
         // Attach leafRouter to intermediateRouter under a parameterized path
@@ -322,16 +300,15 @@ void main() {
         // Attach intermediateRouter to mainRouter under a parameterized path
         mainRouter.attach('/base/:baseId', intermediateRouter);
 
-        final mainMiddleware = RoutingMiddleware(mainRouter);
-        final pipeline = mainMiddleware.meddle(
-            (final RequestContext ctx) async =>
-                (ctx as RespondableContext).withResponse(FakeResponse(404)));
+        final pipelineHandler = const Pipeline()
+            .addMiddleware(routeWith(mainRouter))
+            .addHandler(respondWith((final _) => _FakeResponse(404)));
 
-        final initialCtx = FakeRequest('/base/b123/i456/action/doSomething')
+        final initialCtx = _FakeRequest('/base/b123/i456/action/doSomething')
             .toContext(Object());
-        final resultingCtx = await pipeline(initialCtx);
+        final resultingCtx = await pipelineHandler(initialCtx);
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
 
         expect(deeplyNestedHandlerCalled, isTrue);
         expect(response.statusCode, equals(200));
@@ -365,19 +342,19 @@ void main() {
           // sub-router uses :id
           capturedParams = ctx.pathParameters;
           return (ctx as RespondableContext)
-              .withResponse(FakeResponse(200, parameters: capturedParams));
+              .withResponse(_FakeResponse(200, parameters: capturedParams));
         });
 
         mainRouter.attach('/:id/sub', subRouter); // main router uses :id
 
-        final middleware = RoutingMiddleware(mainRouter);
-        final pipeline = middleware.meddle((final RequestContext ctx) async =>
-            (ctx as RespondableContext).withResponse(FakeResponse(404)));
+        final pipeline = const Pipeline()
+            .addMiddleware(routeWith(mainRouter))
+            .addHandler(respondWith((final _) => _FakeResponse(404)));
 
-        final initialCtx = FakeRequest('/123/sub/456/end').toContext(Object());
+        final initialCtx = _FakeRequest('/123/sub/456/end').toContext(Object());
         final resultingCtx = await pipeline(initialCtx);
         final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
+            (resultingCtx as ResponseContext).response as _FakeResponse;
 
         expect(response.statusCode, 200);
         expect(capturedParams, isNotNull);
@@ -386,37 +363,6 @@ void main() {
         // Parameters: {#id: '123', #id: '456'} -> {#id: '456'}
         expect(capturedParams, equals({#id: '456'}));
         expect(response.parameters, equals({#id: '456'}));
-      });
-    });
-
-    group('routeWith utility', () {
-      test(
-          'Given a router, When routeWith is used to create middleware, Then it functions like RoutingMiddleware',
-          () async {
-        Map<Symbol, String>? capturedParams;
-        Future<ResponseContext> testHandler(final RequestContext ctx) async {
-          capturedParams = ctx.pathParameters;
-          return (ctx as RespondableContext)
-              .withResponse(FakeResponse(200, parameters: capturedParams));
-        }
-
-        router.add(Method.get, '/utils/:param', testHandler);
-
-        final middlewareFunc = routeWith(router);
-        final handlerChain = middlewareFunc((final RequestContext ctx) async {
-          return (ctx as RespondableContext).withResponse(FakeResponse(404));
-        });
-
-        final initialCtx = FakeRequest('/utils/testValue').toContext(Object());
-        final resultingCtx = await handlerChain(initialCtx);
-
-        expect(capturedParams, isNotNull);
-        expect(capturedParams, equals({#param: 'testValue'}));
-        expect(resultingCtx, isA<ResponseContext>());
-        final response =
-            (resultingCtx as ResponseContext).response as FakeResponse;
-        expect(response.statusCode, equals(200));
-        expect(response.parameters, equals({#param: 'testValue'}));
       });
     });
   });

--- a/test/static/test_util.dart
+++ b/test/static/test_util.dart
@@ -18,7 +18,7 @@ Future<Response> makeRequest(
 }) async {
   final rootedHandler = _rootHandler(handlerPath, handler);
   final request = _fromPath(path, headers, method: method);
-  final ctx = await rootedHandler(request.toContext());
+  final ctx = await rootedHandler(request.toContext(Object()));
   if (ctx is! ResponseContext) throw ArgumentError(ctx);
   return ctx.response;
 }
@@ -53,7 +53,7 @@ Handler _rootHandler(final String? path, final Handler handler) {
 
     final relativeRequest = request.copyWith(path: path);
 
-    return handler(relativeRequest.toContext());
+    return handler(relativeRequest.toContext(Object()));
   };
 }
 

--- a/test/util/test_util.dart
+++ b/test/util/test_util.dart
@@ -42,7 +42,8 @@ Future<RequestContext> asyncHandler(final RequestContext ctx) async {
 /// Makes a simple GET request to [handler] and returns the result.
 Future<Response> makeSimpleRequest(final Handler handler,
     [final Request? request]) async {
-  final newCtx = await handler((request ?? _defaultRequest).toContext());
+  final newCtx =
+      await handler((request ?? _defaultRequest).toContext(Object()));
   if (newCtx is! ResponseContext) throw ArgumentError(newCtx);
   return newCtx.response;
 }


### PR DESCRIPTION
## Description
Introduce Routing Middleware and Enhance RequestContext

This PR introduces a new `RoutingMiddleware` to the Relic framework, enabling path-based request handling. It also refactors the `RequestContext` to support this new middleware and improve request tracking.

### Key Changes:

*   **New `RoutingMiddleware` (`relic/lib/src/middleware/routing_middleware.dart`):**
    *   Adds a `routeWith` function to easily integrate a `Router` into the request processing pipeline.
    *   The middleware inspects the request path and method, and if a route matches, it forwards the request to the corresponding handler.
    *   Path parameters extracted by the router are made available to handlers via an extension on `RequestContext` (`ctx.pathParameters`).

*   **`RequestContext` Enhancements (`relic/lib/src/adapter/context.dart`):**
    *   A `token` (an `Object`) has been added to `RequestContext`. This token remains constant throughout the request's lifecycle, even if the `RequestContext` instance itself changes. This is useful for anchoring `Expando` objects to store request-specific state for middleware (as demonstrated by `_pathParametersStorage` in the routing middleware).
    *   Constructors for `NewContext`, `ResponseContext`, and `HijackContext` now accept and store this `token`.
    *   The `request.toContext()` extension now requires a `token` argument.

*   **Example Update (`relic/example/example.dart`):**
    *   The main example has been updated to demonstrate the new routing capabilities.
    *   It now defines a route `/user/:name/age/:age` and a handler `hello` that uses path parameters.
    *   The pipeline now includes `logRequests()` and the new `routeWith(router)` middleware.
    *   A default "Not Found" handler is provided if no routes match.

*   **Server & Testing Updates:**
    *   **`relic/lib/src/relic_server.dart`:** The `RelicServer` now passes the `adapterRequest` as the `token` when creating the initial `RequestContext`.
    *   **`relic/test/static/test_util.dart` & `relic/test/util/test_util.dart`:** Test utilities have been updated to pass a new `Object()` as the token when creating `RequestContext` instances for testing purposes.

### Impact:

*   This change allows developers to define and manage routes within their Relic applications more effectively.
*   The introduction of the `token` in `RequestContext` provides a more robust way for middleware to associate state with a specific request.
*   The example application now showcases a more realistic use-case with path parameters and routing.

## Related Issues
- Closes: #55
- Closes: #57 

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [ ] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [x] Includes breaking changes.

The `Message` class (and hence `Request` and `Response`) no longer holds a context map. Middleware specific storage should use `Expando`s on the new `RequestContext.token`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added routing and middleware support, including request logging and path parameter extraction.
  - Introduced a new routing middleware for structured HTTP request handling and path parameter propagation.

- **Bug Fixes**
  - Improved 404 Not Found responses with custom messages for unmatched routes.

- **Refactor**
  - Enhanced request context handling to include a unique token for better request-specific state management.

- **Tests**
  - Updated test utilities to align with new context creation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->