### PR TITLE
feat: PathTrie wildcard and tail matching support

### DIFF
--- a/lib/src/router/normalized_path.dart
+++ b/lib/src/router/normalized_path.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'lru_cache.dart';
 
 /// Represents a URL path that has been normalized.
@@ -9,6 +11,7 @@ import 'lru_cache.dart';
 ///
 /// Instances are interned using an LRU cache for efficiency, meaning identical
 /// normalized paths will often share the same object instance.
+@immutable
 class NormalizedPath {
   /// Cache of interned instances
   static var interned = LruCache<String, NormalizedPath>(10000);
@@ -19,6 +22,9 @@ class NormalizedPath {
 
   /// Private constructor to create an instance with already normalized segments.
   NormalizedPath._(this.segments);
+
+  /// Empty normalized path instance.
+  static NormalizedPath empty = NormalizedPath._(const []);
 
   /// Creates a [NormalizedPath] from a given [path] string.
   ///
@@ -60,8 +66,14 @@ class NormalizedPath {
   ///
   /// The [start] parameter specifies the starting segment index (inclusive).
   /// The optional [end] parameter specifies the ending segment index (exclusive).
-  NormalizedPath subPath(final int start, [final int? end]) =>
-      NormalizedPath._(segments.sublist(start, end));
+  NormalizedPath subPath(final int start, [int? end]) {
+    end ??= length;
+    if (start == end) return NormalizedPath.empty;
+    if (start == 0 && end == length) {
+      return this; // since NormalizedPath is immutable
+    }
+    return NormalizedPath._(segments.sublist(start, end));
+  }
 
   /// The number of segments in this path
   int get length => segments.length;

--- a/lib/src/router/normalized_path.dart
+++ b/lib/src/router/normalized_path.dart
@@ -59,7 +59,7 @@ class NormalizedPath {
         result.add(segment);
       }
     }
-    return result;
+    return List.unmodifiable(result);
   }
 
   /// Returns a new [NormalizedPath] representing a subpath of this path.

--- a/lib/src/router/path_trie.dart
+++ b/lib/src/router/path_trie.dart
@@ -172,16 +172,29 @@ final class PathTrie<T> {
     final segments = normalizedPath.segments;
     _TrieNode<T> currentNode = _root;
 
+    // Helper function
+    @pragma('vm:prefer-inline')
+    _TrieNode<T>? nextIf<U extends _DynamicSegment<T>>(
+        final _DynamicSegment<T>? dynamicSegment) {
+      if (dynamicSegment != null && dynamicSegment is U) {
+        return dynamicSegment.node;
+      }
+      return null;
+    }
+
     for (final segment in segments) {
       var nextNode = currentNode.children[segment];
       if (nextNode == null) {
+        final dynamicSegment = currentNode.dynamicSegment;
         if (segment == '**') {
           // Handle tail segment
+          nextNode = nextIf<_Tail<T>>(dynamicSegment);
         } else if (segment == '*') {
           // Handle wildcard segment
+          nextNode = nextIf<_Wildcard<T>>(dynamicSegment);
         } else if (segment.startsWith(':')) {
           // Handle parameter segment
-          final parameter = currentNode.dynamicSegment as _Parameter<T>?;
+          final parameter = dynamicSegment as _Parameter<T>?;
           if (parameter != null && parameter.name == segment.substring(1)) {
             nextNode = parameter.node;
           }

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -96,7 +96,14 @@ final class Router<T> {
 
     // Try static cache first
     final value = _staticCache[normalizedPath]?.find(method);
-    if (value != null) return LookupResult(value, const {});
+    if (value != null) {
+      return LookupResult(
+        value,
+        const {},
+        normalizedPath,
+        NormalizedPath.empty,
+      );
+    }
 
     // Fall back to trie
     final entry = _allRoutes.lookup(normalizedPath);
@@ -110,7 +117,12 @@ final class Router<T> {
       _staticCache[normalizedPath] = entry.value;
     }
 
-    return LookupResult(route, entry.parameters);
+    return LookupResult(
+      route,
+      entry.parameters,
+      entry.matched,
+      entry.remaining,
+    );
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   collection: ^1.18.0
   convert: ^3.1.1
   http_parser: ^4.0.2
+  meta: ^1.16.0
   mime: ">=1.0.6 <3.0.0"
   path: ^1.8.3
   stack_trace: ^1.10.0
@@ -31,6 +32,5 @@ dev_dependencies:
   # our direct dependencies indicate.
   file: ^7.0.0 # ignore: sort_pub_dependencies
   frontend_server_client: ^4.0.0
-  meta: ^1.9.1
   pub_semver: ^2.1.4
   watcher: ^1.1.0

--- a/test/router/path_trie_crud_test.dart
+++ b/test/router/path_trie_crud_test.dart
@@ -406,8 +406,7 @@ void main() {
         final specificLookup =
             trie.lookup(NormalizedPath('/files/specific/file.txt'));
         expect(specificLookup?.value, 40,
-            reason:
-                'More specific path should ideally remain if structured correctly.');
+            reason: 'More specific path should remain');
       });
 
       test(

--- a/test/router/path_trie_tail_test.dart
+++ b/test/router/path_trie_tail_test.dart
@@ -1,0 +1,265 @@
+import 'package:relic/src/router/normalized_path.dart';
+import 'package:relic/src/router/path_trie.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PathTrie Tail (**) Matching', () {
+    late PathTrie<int> trie;
+
+    setUp(() {
+      trie = PathTrie<int>();
+    });
+
+    test(
+        'Given a trie with path /static/**, '
+        'when /static/css/style.css is looked up, '
+        'then it matches with correct value and remaining path', () {
+      trie.add(NormalizedPath('/static/**'), 1);
+      final result = trie.lookup(NormalizedPath('/static/css/style.css'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/static');
+      expect(result.remaining.path, '/css/style.css');
+    });
+
+    test(
+        'Given a trie with path /files/**, '
+        'when /files/a/b/c/doc.txt (multiple segments for tail) is looked up, '
+        'then it matches with correct value and remaining path', () {
+      trie.add(NormalizedPath('/files/**'), 1);
+      final result = trie.lookup(NormalizedPath('/files/a/b/c/doc.txt'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/files');
+      expect(result.remaining.path, '/a/b/c/doc.txt');
+    });
+
+    test(
+        'Given a trie with path /archive/**, '
+        'when /archive/ (ends where tail starts) is looked up, '
+        'then it matches with an empty remaining path', () {
+      trie.add(NormalizedPath('/archive/**'), 1);
+      final result = trie.lookup(NormalizedPath('/archive/'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/archive');
+      expect(result.remaining.segments, isEmpty);
+    });
+
+    test(
+        'Given a trie with path /exact/**, '
+        'when /exact (no trailing slash, ends where tail starts) is looked up, '
+        'then it matches with an empty remaining path', () {
+      trie.add(NormalizedPath('/exact/**'), 1);
+      final result = trie.lookup(NormalizedPath('/exact'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/exact');
+      expect(result.remaining.segments, isEmpty);
+    });
+
+    test(
+        'Given a trie with path /**, '
+        'when /any/path/anywhere is looked up, '
+        'then it matches with an empty matched path and correct remaining path',
+        () {
+      trie.add(NormalizedPath('/**'), 1);
+      final result = trie.lookup(NormalizedPath('/any/path/anywhere'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.segments, isEmpty);
+      expect(result.remaining.path, '/any/path/anywhere');
+    });
+
+    group('Root path (/) matching with root tail (/**) interactions', () {
+      setUp(() {
+        // Ensures a fresh trie for each scenario in this group
+        trie = PathTrie<int>();
+      });
+
+      test(
+          'Given a trie with only path /** defined, '
+          'when the root path / is looked up,'
+          'then /** matches with its value and empty matched/remaining paths',
+          () {
+        trie.add(NormalizedPath('/**'), 1);
+        final result = trie.lookup(NormalizedPath('/'));
+        expect(result, isNotNull,
+            reason: 'Lookup for / should find /** if / has no value');
+        expect(result!.value, 1);
+        expect(result.matched.segments, isEmpty,
+            reason: 'Matched path for /** lookup of / should be empty');
+        expect(result.remaining.segments, isEmpty,
+            reason: 'Remaining path for /** lookup of / should be empty');
+      });
+
+      test(
+          'Given a trie with only path / defined, '
+          'when the root path / is looked up, '
+          'then / matches with its value and empty matched/remaining paths',
+          () {
+        trie.add(NormalizedPath('/'), 2);
+        final result = trie.lookup(NormalizedPath('/'));
+        expect(result, isNotNull);
+        expect(result!.value, 2);
+        expect(result.matched.segments, isEmpty);
+        expect(result.remaining.segments, isEmpty);
+      });
+
+      test(
+          'Given a trie with path / and path /** defined, '
+          'when the root path / is looked up, '
+          'then the literal path / takes precedence with its value', () {
+        trie.add(NormalizedPath('/'), 2);
+        trie.add(NormalizedPath('/**'), 3); // /** has a different value
+
+        final result = trie.lookup(NormalizedPath('/'));
+        expect(result, isNotNull,
+            reason: 'Lookup for / should prefer value on / over /**');
+        expect(result!.value, 2, reason: 'Value from / should be preferred');
+        expect(result.matched.segments, isEmpty);
+        expect(result.remaining.segments, isEmpty);
+      });
+
+      test(
+          'Given a trie with path / and path /** defined, '
+          'when a sub-path like /some/path is looked up, '
+          'then path /** matches with its value and correct remaining path',
+          () {
+        trie.add(NormalizedPath('/'), 2);
+        trie.add(NormalizedPath('/**'), 3);
+
+        final result = trie.lookup(NormalizedPath('/some/path'));
+        expect(result, isNotNull,
+            reason: '/** should still match longer paths');
+        expect(result!.value, 3,
+            reason: 'Value from /** should match longer paths');
+        expect(result.matched.segments, isEmpty);
+        expect(result.remaining.path, '/some/path');
+      });
+    });
+
+    test(
+        'Given a trie with /assets/js/app.js and /assets/**, '
+        'when paths are looked up, '
+        'then literal is preferred and tail matches remaining', () {
+      trie.add(NormalizedPath('/assets/js/app.js'), 1);
+      trie.add(NormalizedPath('/assets/**'), 2);
+
+      final literalResult = trie.lookup(NormalizedPath('/assets/js/app.js'));
+      expect(literalResult, isNotNull);
+      expect(literalResult!.value, 1);
+      expect(literalResult.matched.path, '/assets/js/app.js');
+      expect(literalResult.remaining.segments, isEmpty);
+
+      final tailResult = trie.lookup(NormalizedPath('/assets/img/logo.png'));
+      expect(tailResult, isNotNull);
+      expect(tailResult!.value, 2);
+      expect(tailResult.matched.path, '/assets');
+      expect(tailResult.remaining.path, '/img/logo.png');
+    });
+
+    test(
+        'Given a trie with /foo/bar/** and /foo/**, '
+        'when paths are looked up, '
+        'then the more specific /foo/bar/** is chosen over /foo/**', () {
+      trie.add(NormalizedPath('/foo/bar/**'), 1);
+      trie.add(NormalizedPath('/foo/**'), 2);
+
+      final resSpecific = trie.lookup(NormalizedPath('/foo/bar/baz/qux'));
+      expect(resSpecific, isNotNull);
+      expect(resSpecific!.value, 1);
+      expect(resSpecific.matched.path, '/foo/bar');
+      expect(resSpecific.remaining.path, '/baz/qux');
+
+      final resGeneral = trie.lookup(NormalizedPath('/foo/other/path'));
+      expect(resGeneral, isNotNull);
+      expect(resGeneral!.value, 2);
+      expect(resGeneral.matched.path, '/foo');
+      expect(resGeneral.remaining.path, '/other/path');
+    });
+
+    test(
+        'Given a trie with path /user/:id/files/**, '
+        'when /user/42/files/docs/report.pdf is looked up, '
+        'then it matches with correct parameter and remaining path', () {
+      trie.add(NormalizedPath('/user/:id/files/**'), 1);
+      final result =
+          trie.lookup(NormalizedPath('/user/42/files/docs/report.pdf'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, equals({#id: '42'}));
+      expect(result.matched.path, '/user/42/files');
+      expect(result.remaining.path, '/docs/report.pdf');
+    });
+
+    test(
+        'Given a trie with path /data/export/**, '
+        'when /data (shorter than prefix) is looked up, '
+        'then no match is found', () {
+      trie.add(NormalizedPath('/data/export/**'), 1);
+      expect(trie.lookup(NormalizedPath('/data')), isNull);
+    });
+
+    test(
+        'Given an empty trie, '
+        'when adding a path like /**foo (tail not a full segment), '
+        'then an ArgumentError is thrown', () {
+      expect(() => trie.add(NormalizedPath('/downloads/**foo'), 1),
+          throwsArgumentError);
+    });
+
+    group('Tail and Other Segment interaction validation', () {
+      test(
+          'Given a trie with /test/**, '
+          'when adding /test/:id (parameter after tail at same level), '
+          'then an ArgumentError is thrown', () {
+        trie.add(NormalizedPath('/test/**'), 1);
+        expect(() => trie.add(NormalizedPath('/test/:id'), 2),
+            throwsArgumentError);
+      });
+
+      test(
+          'Given a trie with /test/:id, '
+          'when adding /test/** (tail after parameter at same level), '
+          'then an ArgumentError is thrown', () {
+        trie.add(NormalizedPath('/test/:id'), 1);
+        expect(
+            () => trie.add(NormalizedPath('/test/**'), 2), throwsArgumentError);
+      });
+
+      test(
+          'Given a trie with /test/**, '
+          'when adding /test/* (wildcard after tail at same level), '
+          'then an ArgumentError is thrown', () {
+        trie.add(NormalizedPath('/test/**'), 1);
+        expect(
+            () => trie.add(NormalizedPath('/test/*'), 2), throwsArgumentError);
+      });
+
+      test(
+          'Given a trie with /test/*, '
+          'when adding /test/** (tail after wildcard at same level), '
+          'then an ArgumentError is thrown', () {
+        trie.add(NormalizedPath('/test/*'), 1);
+        expect(
+            () => trie.add(NormalizedPath('/test/**'), 2), throwsArgumentError);
+      });
+
+      test(
+          'Given an empty trie, '
+          'when adding a path /a/**/b/c (tail /** not as the last segment), '
+          'then an ArgumentError is thrown', () {
+        expect(
+            () => trie.add(NormalizedPath('/a/**/b/c'), 1), throwsArgumentError,
+            reason:
+                'Tail segment /** must be the last segment in a path definition.');
+      });
+    });
+  });
+}

--- a/test/router/path_trie_tail_test.dart
+++ b/test/router/path_trie_tail_test.dart
@@ -24,45 +24,6 @@ void main() {
     });
 
     test(
-        'Given a trie with path /files/**, '
-        'when /files/a/b/c/doc.txt (multiple segments for tail) is looked up, '
-        'then it matches with correct value and remaining path', () {
-      trie.add(NormalizedPath('/files/**'), 1);
-      final result = trie.lookup(NormalizedPath('/files/a/b/c/doc.txt'));
-      expect(result, isNotNull);
-      expect(result!.value, 1);
-      expect(result.parameters, isEmpty);
-      expect(result.matched.path, '/files');
-      expect(result.remaining.path, '/a/b/c/doc.txt');
-    });
-
-    test(
-        'Given a trie with path /archive/**, '
-        'when /archive/ (ends where tail starts) is looked up, '
-        'then it matches with an empty remaining path', () {
-      trie.add(NormalizedPath('/archive/**'), 1);
-      final result = trie.lookup(NormalizedPath('/archive/'));
-      expect(result, isNotNull);
-      expect(result!.value, 1);
-      expect(result.parameters, isEmpty);
-      expect(result.matched.path, '/archive');
-      expect(result.remaining.segments, isEmpty);
-    });
-
-    test(
-        'Given a trie with path /exact/**, '
-        'when /exact (no trailing slash, ends where tail starts) is looked up, '
-        'then it matches with an empty remaining path', () {
-      trie.add(NormalizedPath('/exact/**'), 1);
-      final result = trie.lookup(NormalizedPath('/exact'));
-      expect(result, isNotNull);
-      expect(result!.value, 1);
-      expect(result.parameters, isEmpty);
-      expect(result.matched.path, '/exact');
-      expect(result.remaining.segments, isEmpty);
-    });
-
-    test(
         'Given a trie with path /**, '
         'when /any/path/anywhere is looked up, '
         'then it matches with an empty matched path and correct remaining path',
@@ -208,47 +169,52 @@ void main() {
 
     test(
         'Given an empty trie, '
-        'when adding a path like /**foo (tail not a full segment), '
+        'when adding a path like /**foo, '
         'then an ArgumentError is thrown', () {
       expect(() => trie.add(NormalizedPath('/downloads/**foo'), 1),
-          throwsArgumentError);
+          throwsArgumentError,
+          reason: 'Tail not a full segment');
     });
 
     group('Tail and Other Segment interaction validation', () {
       test(
           'Given a trie with /test/**, '
-          'when adding /test/:id (parameter after tail at same level), '
+          'when adding /test/:id, '
           'then an ArgumentError is thrown', () {
         trie.add(NormalizedPath('/test/**'), 1);
-        expect(() => trie.add(NormalizedPath('/test/:id'), 2),
-            throwsArgumentError);
+        expect(
+            () => trie.add(NormalizedPath('/test/:id'), 2), throwsArgumentError,
+            reason: 'Parameter after tail at same level');
       });
 
       test(
           'Given a trie with /test/:id, '
-          'when adding /test/** (tail after parameter at same level), '
+          'when adding /test/**, '
           'then an ArgumentError is thrown', () {
         trie.add(NormalizedPath('/test/:id'), 1);
         expect(
-            () => trie.add(NormalizedPath('/test/**'), 2), throwsArgumentError);
+            () => trie.add(NormalizedPath('/test/**'), 2), throwsArgumentError,
+            reason: 'Tail after parameter at same level');
       });
 
       test(
           'Given a trie with /test/**, '
-          'when adding /test/* (wildcard after tail at same level), '
+          'when adding /test/*, '
           'then an ArgumentError is thrown', () {
         trie.add(NormalizedPath('/test/**'), 1);
         expect(
-            () => trie.add(NormalizedPath('/test/*'), 2), throwsArgumentError);
+            () => trie.add(NormalizedPath('/test/*'), 2), throwsArgumentError,
+            reason: 'Wildcard after tail at same level');
       });
 
       test(
           'Given a trie with /test/*, '
-          'when adding /test/** (tail after wildcard at same level), '
+          'when adding /test/**, '
           'then an ArgumentError is thrown', () {
         trie.add(NormalizedPath('/test/*'), 1);
         expect(
-            () => trie.add(NormalizedPath('/test/**'), 2), throwsArgumentError);
+            () => trie.add(NormalizedPath('/test/**'), 2), throwsArgumentError,
+            reason: 'Tail after wildcard at same level');
       });
 
       test(
@@ -257,8 +223,7 @@ void main() {
           'then an ArgumentError is thrown', () {
         expect(
             () => trie.add(NormalizedPath('/a/**/b/c'), 1), throwsArgumentError,
-            reason:
-                'Tail segment /** must be the last segment in a path definition.');
+            reason: 'Tail /** not as the last segment.');
       });
     });
   });

--- a/test/router/path_trie_wildcard_test.dart
+++ b/test/router/path_trie_wildcard_test.dart
@@ -88,7 +88,7 @@ void main() {
 
     test(
         'Given a trie with path /assets/*, '
-        'when /assets/img/logo.png (wildcard part spans multiple segments) is looked up, '
+        'when /assets/img/logo.png is looked up, '
         'then no match is found', () {
       trie.add(NormalizedPath('/assets/*'), 1);
       expect(trie.lookup(NormalizedPath('/assets/img/logo.png')), isNull);
@@ -125,29 +125,32 @@ void main() {
 
     test(
         'Given an empty trie, '
-        'when adding a path like /*foo/bar (wildcard not a full segment), '
+        'when adding a path like /*foo/bar, '
         'then an ArgumentError is thrown', () {
       expect(
-          () => trie.add(NormalizedPath('/*foo/bar'), 1), throwsArgumentError);
+          () => trie.add(NormalizedPath('/*foo/bar'), 1), throwsArgumentError,
+          reason: 'Wildcard not a full segment');
     });
 
     group('Wildcard and Parameter interaction validation', () {
       test(
           'Given a trie with /test/*, '
-          'when adding /test/:id (parameter after wildcard at same level), '
+          'when adding /test/:id, '
           'then an ArgumentError is thrown', () {
         trie.add(NormalizedPath('/test/*'), 1);
-        expect(() => trie.add(NormalizedPath('/test/:id'), 2),
-            throwsArgumentError);
+        expect(
+            () => trie.add(NormalizedPath('/test/:id'), 2), throwsArgumentError,
+            reason: 'Parameter after wildcard at same level');
       });
 
       test(
           'Given a trie with /test/:id, '
-          'when adding /test/* (wildcard after parameter at same level), '
+          'when adding /test/*, '
           'then an ArgumentError is thrown', () {
         trie.add(NormalizedPath('/test/:id'), 1);
         expect(
-            () => trie.add(NormalizedPath('/test/*'), 2), throwsArgumentError);
+            () => trie.add(NormalizedPath('/test/*'), 2), throwsArgumentError,
+            reason: 'Wildcard after parameter at same level');
       });
     });
   });

--- a/test/router/path_trie_wildcard_test.dart
+++ b/test/router/path_trie_wildcard_test.dart
@@ -1,0 +1,154 @@
+import 'package:relic/src/router/normalized_path.dart';
+import 'package:relic/src/router/path_trie.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PathTrie Wildcard (*) Matching', () {
+    late PathTrie<int> trie;
+
+    setUp(() {
+      trie = PathTrie<int>();
+    });
+
+    test(
+        'Given a trie with path /users/*/profile, '
+        'when /users/123/profile is looked up, '
+        'then it matches with correct value and paths', () {
+      trie.add(NormalizedPath('/users/*/profile'), 1);
+      final result = trie.lookup(NormalizedPath('/users/123/profile'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/users/123/profile');
+      expect(result.remaining.segments, isEmpty);
+    });
+
+    test(
+        'Given a trie with path /*/resource, '
+        'when /any/resource is looked up, '
+        'then it matches with correct value and paths', () {
+      trie.add(NormalizedPath('/*/resource'), 1);
+      final result = trie.lookup(NormalizedPath('/any/resource'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/any/resource');
+      expect(result.remaining.segments, isEmpty);
+    });
+
+    test(
+        'Given a trie with path /files/*, '
+        'when /files/image.jpg is looked up, '
+        'then it matches with correct value and paths', () {
+      trie.add(NormalizedPath('/files/*'), 1);
+      final result = trie.lookup(NormalizedPath('/files/image.jpg'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/files/image.jpg');
+      expect(result.remaining.segments, isEmpty);
+    });
+
+    test(
+        'Given a trie with path /a/*/c/*, '
+        'when /a/b/c/d is looked up, '
+        'then it matches with correct value and paths', () {
+      trie.add(NormalizedPath('/a/*/c/*'), 1);
+      final result = trie.lookup(NormalizedPath('/a/b/c/d'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, isEmpty);
+      expect(result.matched.path, '/a/b/c/d');
+      expect(result.remaining.segments, isEmpty);
+    });
+
+    test(
+        'Given a trie with path /a/*/b, '
+        'when /a/b (fewer segments) is looked up, '
+        'then no match is found', () {
+      trie.add(NormalizedPath('/a/*/b'), 1);
+      expect(trie.lookup(NormalizedPath('/a/b')), isNull);
+    });
+
+    test(
+        'Given a trie with /data/specific and /data/*, '
+        'when they are looked up, '
+        'then literal /data/specific is preferred over /data/*, and /data/* matches other segments',
+        () {
+      trie.add(NormalizedPath('/data/specific'), 1);
+      trie.add(NormalizedPath('/data/*'), 2);
+      final result = trie.lookup(NormalizedPath('/data/specific'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+
+      final wildResult = trie.lookup(NormalizedPath('/data/general'));
+      expect(wildResult, isNotNull);
+      expect(wildResult!.value, 2);
+    });
+
+    test(
+        'Given a trie with path /assets/*, '
+        'when /assets/img/logo.png (wildcard part spans multiple segments) is looked up, '
+        'then no match is found', () {
+      trie.add(NormalizedPath('/assets/*'), 1);
+      expect(trie.lookup(NormalizedPath('/assets/img/logo.png')), isNull);
+    });
+
+    test(
+        'Given a trie with path /api/:version/data/*, '
+        'when /api/v1/data/users is looked up, '
+        'then it matches with correct value, parameter, and paths', () {
+      trie.add(NormalizedPath('/api/:version/data/*'), 1);
+      final result = trie.lookup(NormalizedPath('/api/v1/data/users'));
+      expect(result, isNotNull);
+      expect(result!.value, 1);
+      expect(result.parameters, equals({#version: 'v1'}));
+      expect(result.matched.path, '/api/v1/data/users');
+      expect(result.remaining.segments, isEmpty);
+    });
+
+    test(
+        'Given a trie with path /a/b/*/d, '
+        'when /a/b/c (shorter) is looked up, '
+        'then no match is found', () {
+      trie.add(NormalizedPath('/a/b/*/d'), 1);
+      expect(trie.lookup(NormalizedPath('/a/b/c')), isNull);
+    });
+
+    test(
+        'Given a trie with path /a/b/* (no tail), '
+        'when /a/b/c/d (longer) is looked up, '
+        'then no match is found', () {
+      trie.add(NormalizedPath('/a/b/*'), 1);
+      expect(trie.lookup(NormalizedPath('/a/b/c/d')), isNull);
+    });
+
+    test(
+        'Given an empty trie, '
+        'when adding a path like /*foo/bar (wildcard not a full segment), '
+        'then an ArgumentError is thrown', () {
+      expect(
+          () => trie.add(NormalizedPath('/*foo/bar'), 1), throwsArgumentError);
+    });
+
+    group('Wildcard and Parameter interaction validation', () {
+      test(
+          'Given a trie with /test/*, '
+          'when adding /test/:id (parameter after wildcard at same level), '
+          'then an ArgumentError is thrown', () {
+        trie.add(NormalizedPath('/test/*'), 1);
+        expect(() => trie.add(NormalizedPath('/test/:id'), 2),
+            throwsArgumentError);
+      });
+
+      test(
+          'Given a trie with /test/:id, '
+          'when adding /test/* (wildcard after parameter at same level), '
+          'then an ArgumentError is thrown', () {
+        trie.add(NormalizedPath('/test/:id'), 1);
+        expect(
+            () => trie.add(NormalizedPath('/test/*'), 2), throwsArgumentError);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

This change introduces support for wildcard (`*`) and tail (`**`) path segments in the `PathTrie` for more flexible route matching, along with related improvements to `NormalizedPath` and `Router`.

**Key Changes:**

*   **`PathTrie` Enhancements:**
    *   Introduces internal support for new dynamic segment types: `_Wildcard<T>` and `_Tail<T>`, alongside the existing `_Parameter<T>`.
    *   `LookupResult` now includes `matched` (the part of the path that matched up to and including dynamic segments) and `remaining` (the part of the path consumed by a `**` tail match).
    *   The `_build` method now handles the creation of nodes for `*` and `**` segments. It includes validation to ensure:
        *   `*` and `**` are standalone segments (e.g., `*foo` or `/**bar` are invalid).
        *   `**` (tail segment) must be the last segment in a path definition.
        *   Conflicting dynamic segment types cannot be defined at the same level in the trie.
    *   The `lookup` method is updated to:
        *   Recognize and match `*` and `**` segments.
        *   Correctly populate parameters, `matched` path, and `remaining` path in the `LookupResult`.
        *   Handle tail matches that consume zero remaining segments (e.g., route `/archive/**` matching lookup path `/archive`).

*   **`NormalizedPath` Improvements:**
    *   Added `@immutable` annotation.
    *   Introduced `NormalizedPath.empty` static instance for an empty path.
    *   Optimized `subPath` method to return `NormalizedPath.empty` for zero-length subpaths or `this` if the subpath covers the entire original path, improving efficiency by leveraging immutability.

*   **`Router` Update:**
    *   The `lookup` method in `Router` has been updated to correctly construct `LookupResult` with the new `matched` and `remaining` path fields from the `PathTrie`'s lookup result.

*   **Testing:**
    *   Adds new test files (`path_trie_tail_test.dart`, `path_trie_wildcard_test.dart`)

## Related Issues
- Closes: #72 
- Closes: #73 

## Benchmark results
2,4 GHz 8-Core Intel Core i9
```
./benchmark/benchmark.exe
Setting up benchmark data with 10000 routes...
Setup complete.
Starting benchmarks
---
Static Add
Routingkit Add Static x10000(RunTime): 10554.986013986014 us.
Spanner Add Static x10000(RunTime): 14277.356643356643 us.
Router Add Static x10000(RunTime): 7479.325373134328 us.
---
Static Lookup
Routingkit Lookup Static x10000(RunTime): 2231.669 us.
Spanner Lookup Static x10000(RunTime): 1741.7113943028485 us.
Router Lookup Static x10000(RunTime): 1523.3925 us.
---
Dynamic Add
Routingkit Add Dynamic x10000(RunTime): 14911.438461538462 us.
Spanner Add Dynamic x10000(RunTime): 59344.606060606064 us.
Router Add Dynamic x10000(RunTime): 10461.368644067798 us.
---
Dynamic Lookup
Routingkit Lookup Dynamic x10000(RunTime): 19026.396226415094 us.
Spanner Lookup Dynamic x10000(RunTime): 5818.2692307692305 us.
Router Lookup Dynamic x10000(RunTime): 3777.58 us.
Done
```

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced routing to support wildcard (*) and tail wildcard (**) path segments for more flexible route matching.
  - Lookup results now provide detailed information about matched and remaining path segments.
  - Optimized path handling with immutable paths and reuse of empty path instances.

- **Bug Fixes**
  - Improved error handling and validation for invalid or conflicting route definitions.

- **Tests**
  - Added comprehensive tests for wildcard and tail wildcard matching, including precedence, parameter extraction, and error scenarios.

- **Chores**
  - Updated the meta package dependency for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->