### PR TITLE
feat: The routeWith middleware builder function is now generic.

### DIFF
--- a/test/middleware/routing_middleware_test.dart
+++ b/test/middleware/routing_middleware_test.dart
@@ -350,7 +350,7 @@ void main() {
         'then the request.method is "${v.key}"',
     (final v) async {
       late RequestMethod method;
-      final middleware = routeWith(Router()
+      final middleware = routeWith(Router<Handler>()
         ..add(v.value, '/', respondWith((final req) {
           method = req.method;
           return Response.ok();

--- a/test/middleware/routing_middleware_test.dart
+++ b/test/middleware/routing_middleware_test.dart
@@ -331,6 +331,28 @@ void main() {
     });
   });
 
+  test(
+    'Given `routeWith` adapting a `Router<String>`, '
+    'When a request matches a route, '
+    "Then the `toHandler` processes the route's string value",
+    () async {
+      final strRouter = Router<String>()..add(Method.get, '/', 'Hurrah!');
+      final mw = routeWith<String>(
+        strRouter,
+        toHandler: (final s) =>
+            respondWith((final _) => Response.ok(body: Body.fromString(s))),
+      );
+
+      final ctx = _FakeRequest('/').toContext(Object());
+      final resCtx =
+          await mw(respondWith((final _) => Response.notFound()))(ctx)
+              as ResponseContext;
+
+      expect(resCtx.response.statusCode, 200);
+      expect(await resCtx.response.readAsString(), 'Hurrah!');
+    },
+  );
+
   // Due to the decoupling of Router<T> a mapping has to happen
   // for verbs. These test ensures all mappings are exercised.
   parameterizedTest(


### PR DESCRIPTION
## Description
This pull request introduces a feature that makes the `routeWith` middleware builder function generic.
You can pass any Router<T> as long as you also pass a toHandler function that tells the middleware how
to produce a handler from a stored route.

Key changes:
- The `routeWith` function in `lib/src/middleware/routing_middleware.dart` now accepts a generic `Router<T>` and an optional `toHandler` function to convert `T` to a `Handler`.
- If `T` is already a `Handler` (or a subtype), and no `toHandler` is provided, it will be automatically cast.
- Tests in `test/middleware/routing_middleware_test.dart` were updated to reflect this change, specifically by parameterizing `Router` as `Router<Handler>()`.

## Related Issues
- Closes: ?

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
Signature of `routeWith` changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved routing middleware to support routers with any handler type, providing greater flexibility for advanced routing scenarios.

- **Tests**
  - Updated tests to align with the new routing middleware enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->