### PR TITLE
docs: Update router entry comment

### DIFF
--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -16,7 +16,7 @@ enum Method {
   connect,
 }
 
-/// A wrapper around a fix length list used for mapping between method and value
+/// A wrapper around a fixed-length list used for mapping between method and value
 /// for each registered path.
 extension type _RouterEntry<T>._(List<T?> _routeByVerb) {
   _RouterEntry()


### PR DESCRIPTION
## Summary
- fix the comment describing `_RouterEntry`'s internal list

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: `dart` not installed)*
- `dart analyze` *(fails: `dart` not installed)*
- `dart test` *(fails: `dart` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683d9f2755888330bdb349087a07730e