### PR TITLE
fix: Fix request/response header sets

### DIFF
--- a/lib/src/headers/headers.dart
+++ b/lib/src/headers/headers.dart
@@ -332,8 +332,8 @@ class Headers extends HeadersBase {
     xPoweredBy,
   };
 
-  static const response = {..._common, ..._requestOnly};
-  static const request = {..._common, ..._responseOnly};
+  static const response = {..._common, ..._responseOnly};
+  static const request = {..._common, ..._requestOnly};
   static const all = {..._common, ..._requestOnly, ..._responseOnly};
 
   /// Request Headers


### PR DESCRIPTION
## Summary
- fix mixup between request and response header collections

## Testing
- `dart test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683d9f74f84083308c1bdc1a924c7793