### PR TITLE
feat: Add ContextProperty class (wraps Expando)

### DIFF
--- a/lib/relic.dart
+++ b/lib/relic.dart
@@ -19,6 +19,7 @@ export 'src/io/static/static_handler.dart';
 export 'src/message/request.dart' show Request;
 export 'src/message/response.dart' show Response;
 export 'src/method/request_method.dart' show RequestMethod;
+export 'src/middleware/context_property.dart';
 export 'src/middleware/middleware.dart' show Middleware, createMiddleware;
 export 'src/middleware/middleware_extensions.dart' show MiddlewareExtensions;
 export 'src/middleware/middleware_logger.dart' show logRequests;

--- a/lib/src/middleware/context_property.dart
+++ b/lib/src/middleware/context_property.dart
@@ -1,4 +1,4 @@
-import '../../relic.dart';
+import '../adapter/context.dart';
 
 /// Manages a piece of data associated with a specific [RequestContext].
 ///

--- a/lib/src/middleware/context_property.dart
+++ b/lib/src/middleware/context_property.dart
@@ -1,0 +1,84 @@
+import '../../relic.dart';
+
+/// Manages a piece of data associated with a specific [RequestContext].
+///
+/// `ContextProperty` allows middleware or other parts of the request handling
+/// pipeline to store and retrieve data scoped to a single request. It uses an
+/// [Expando] internally, keyed by a token from the [RequestContext], to ensure
+/// that data does not leak between requests.
+///
+/// This is useful for passing information like authenticated user objects,
+/// request-specific configurations, or other contextual data through different
+/// layers of an application.
+///
+/// Example:
+/// ```dart
+/// // Define a context property for a user object.
+/// final _currentUserProperty = ContextProperty<User>('currentUser');
+///
+/// // In a middleware, set the user for the current request.
+/// void authMiddleware(RequestContext context, User user) {
+///   currentUserProperty[context] = user;
+/// }
+///
+/// // Later, in a handler, retrieve the user.
+/// User? getCurrentUser(RequestContext context) {
+///   return currentUserProperty.getOrNull(context);
+/// }
+/// ```
+class ContextProperty<T extends Object> {
+  final Expando<T> _storage; // Use token from RequestContext as anchor
+  final String? _debugName; // Optional: for Expando's name
+
+  /// Creates a new `ContextProperty`.
+  ///
+  /// The optional [_debugName] can be used to identify the property in
+  /// debugging scenarios. It is also used as the name for the underlying
+  /// [Expando].
+  ContextProperty([this._debugName]) : _storage = Expando<T>(_debugName);
+
+  /// Retrieves the value associated with the given [requestContext].
+  ///
+  /// Throws a [StateError] if no value is found for the [requestContext]'s token
+  /// and the property has not been set. This ensures that accidental access
+  /// to an uninitialized property is caught early.
+  T operator [](final RequestContext requestContext) {
+    return _storage[requestContext.token] ??
+        (throw StateError(
+            'ContextProperty value not found. Property: ${_debugName ?? T.toString()}. '
+            'Ensure middleware has set this value for the request token.'));
+  }
+
+  /// Retrieves the value associated with the given [requestContext], or `null` if no value is set.
+  ///
+  /// This method is a non-throwing alternative to the `operator []`.
+  /// Use this when it's acceptable for the property to be absent.
+  T? getOrNull(final RequestContext requestContext) {
+    return _storage[requestContext.token];
+  }
+
+  /// Sets the [value] for the given [requestContext].
+  ///
+  /// Associates the [value] with the [requestContext]'s token, allowing it
+  /// to be retrieved later using `operator []` or `getOrNull`.
+  void operator []=(final RequestContext requestContext, final T value) {
+    _storage[requestContext.token] = value;
+  }
+
+  /// Checks if a value exists for the given [requestContext].
+  ///
+  /// Returns `true` if a non-null value has been set for the [requestContext]'s
+  /// token, `false` otherwise.
+  bool exists(final RequestContext requestContext) {
+    return _storage[requestContext.token] != null;
+  }
+
+  /// Clears the value associated with the given [requestContext].
+  ///
+  /// This effectively removes the association in the underlying [Expando],
+  /// causing subsequent gets for this [requestContext] (and this property)
+  /// to return `null` (for `getOrNull`) or throw (for `operator []`).
+  void clear(final RequestContext requestContext) {
+    _storage[requestContext.token] = null; // Clears the association in Expando
+  }
+}

--- a/lib/src/middleware/routing_middleware.dart
+++ b/lib/src/middleware/routing_middleware.dart
@@ -2,6 +2,7 @@ import '../adapter/context.dart';
 import '../handler/handler.dart';
 import '../method/request_method.dart';
 import '../router/router.dart';
+import 'context_property.dart';
 import 'middleware.dart';
 
 Middleware routeWith<T>(
@@ -10,7 +11,7 @@ Middleware routeWith<T>(
 }) =>
     _RoutingMiddlewareBuilder(router, toHandler: toHandler).build();
 
-final _pathParametersStorage = Expando<Map<Symbol, String>>();
+final _pathParametersStorage = ContextProperty<Map<Symbol, String>>();
 
 class _RoutingMiddlewareBuilder<T> {
   final Router<T> _router;
@@ -47,12 +48,10 @@ class _RoutingMiddlewareBuilder<T> {
 }
 
 extension RequestContextEx on RequestContext {
-  Map<Symbol, String> get pathParameters =>
-      _pathParametersStorage[token] ??
-      (throw StateError('Add RoutingMiddleware!'));
+  Map<Symbol, String> get pathParameters => _pathParametersStorage[this];
 
   set _pathParameters(final Map<Symbol, String> value) =>
-      _pathParametersStorage[token] = value;
+      _pathParametersStorage[this] = value;
 }
 
 bool _isSubtype<S, T>() => <S>[] is List<T>;

--- a/test/src/middleware/context_property_test.dart
+++ b/test/src/middleware/context_property_test.dart
@@ -1,0 +1,250 @@
+import 'package:relic/relic.dart';
+import 'package:relic/src/adapter/context.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ContextProperty', () {
+    late ContextProperty<String> stringProperty;
+    late ContextProperty<int> intProperty;
+    late RequestContext context1;
+    late RequestContext context2;
+
+    setUp(() {
+      stringProperty = ContextProperty<String>('testStringProperty');
+      intProperty = ContextProperty<int>();
+
+      final request1 =
+          Request(RequestMethod.get, Uri.parse('http://test.com/test1'));
+      final request2 =
+          Request(RequestMethod.get, Uri.parse('http://test.com/test2'));
+
+      context1 = request1.toContext(Object());
+      context2 = request2.toContext(Object());
+    });
+
+    test(
+        'Given a ContextProperty and a RequestContext, '
+        'when a value is set for the context using the property, '
+        'then the same value can be retrieved', () {
+      const value = 'hello world';
+
+      stringProperty[context1] = value;
+      final retrievedValue = stringProperty[context1];
+
+      expect(retrievedValue, value);
+    });
+
+    test(
+        'Given a ContextProperty with a debug name and a RequestContext for which no value is set, '
+        'when the value is accessed using the [] operator, '
+        'then a StateError is thrown with a message containing the debug name',
+        () {
+      expect(
+        () => stringProperty[context1],
+        throwsA(isA<StateError>().having(
+          (final e) => e.message,
+          'message',
+          contains(
+              'ContextProperty value not found. Property: testStringProperty.'),
+        )),
+      );
+    });
+
+    test(
+        'Given a ContextProperty (for int type, no debug name) and a RequestContext for which no value is set, '
+        'when the value is accessed using the [] operator, '
+        'then a StateError is thrown with a message containing the type name',
+        () {
+      expect(
+        () => intProperty[context1],
+        throwsA(isA<StateError>().having(
+          (final e) => e.message,
+          'message',
+          contains('ContextProperty value not found. Property: int.'),
+        )),
+      );
+    });
+
+    test(
+        'Given a ContextProperty and a RequestContext for which no value is set, '
+        'when getOrNull is called, '
+        'then null is returned', () {
+      final result = stringProperty.getOrNull(context1);
+      expect(result, isNull);
+    });
+
+    test(
+        'Given a ContextProperty and a RequestContext, '
+        'when a value is set and then retrieved using getOrNull, '
+        'then the originally set value is returned', () {
+      const value = 'test value';
+      stringProperty[context1] = value;
+
+      final retrievedValue = stringProperty.getOrNull(context1);
+
+      expect(retrievedValue, value);
+    });
+
+    test(
+        'Given a ContextProperty and a RequestContext for which no value is set, '
+        'when exists is called, '
+        'then false is returned', () {
+      final result = stringProperty.exists(context1);
+
+      expect(result, isFalse);
+    });
+
+    test(
+        'Given a ContextProperty and a RequestContext, '
+        'when a value is set and exists is called, '
+        'then true is returned', () {
+      const value = 'exists';
+      stringProperty[context1] = value;
+
+      final result = stringProperty.exists(context1);
+
+      expect(result, isTrue);
+    });
+
+    test(
+        'Given a ContextProperty and a RequestContext with a set value, '
+        'when clear is called for the context, '
+        'then the value is removed and subsequent accesses reflect this', () {
+      stringProperty[context1] = 'to be cleared';
+      expect(stringProperty.exists(context1), isTrue,
+          reason: 'Pre-condition: value should exist');
+
+      stringProperty.clear(context1);
+
+      expect(stringProperty.exists(context1), isFalse);
+      expect(stringProperty.getOrNull(context1), isNull);
+      expect(
+        () => stringProperty[context1],
+        throwsStateError,
+      );
+    });
+
+    test(
+        'Given a ContextProperty and two RequestContexts with values set for both, '
+        'when clear is called for the first context, '
+        'then only the first context value is removed and the second remains unaffected',
+        () {
+      stringProperty[context1] = 'value1';
+      stringProperty[context2] = 'value2';
+
+      stringProperty.clear(context1);
+
+      expect(stringProperty.exists(context1), isFalse);
+      expect(stringProperty.exists(context2), isTrue);
+      expect(stringProperty[context2], 'value2');
+    });
+
+    test(
+        'Given a ContextProperty and two different RequestContext instances, '
+        'when different values are set for each context using the same property, '
+        'then retrieving values for each context returns their respective, isolated values',
+        () {
+      const value1 = 'value for context1';
+      const value2 = 'value for context2';
+
+      stringProperty[context1] = value1;
+      stringProperty[context2] = value2;
+
+      expect(stringProperty[context1], value1);
+      expect(stringProperty[context2], value2);
+      expect(stringProperty.getOrNull(context1), value1);
+      expect(stringProperty.getOrNull(context2), value2);
+    });
+
+    test(
+        'Given a single RequestContext and multiple different ContextProperty instances, '
+        'when different values are set for the same context using these different properties, '
+        'then retrieving values using each property returns its respective, isolated value',
+        () {
+      final anotherStringProperty = ContextProperty<String>('anotherString');
+      const valStrProp = 'value for stringProperty';
+      const valAnotherStrProp = 'value for anotherStringProperty';
+      const valIntProp = 123;
+
+      stringProperty[context1] = valStrProp;
+      anotherStringProperty[context1] = valAnotherStrProp;
+      intProperty[context1] = valIntProp;
+
+      expect(stringProperty[context1], valStrProp);
+      expect(anotherStringProperty[context1], valAnotherStrProp);
+      expect(intProperty[context1], valIntProp);
+    });
+
+    test(
+        'Given a ContextProperty and a RequestContext, '
+        'when a value is set and then clear is called, '
+        'then exists returns true after setting and false after clearing', () {
+      const value = 'temporary';
+
+      stringProperty[context1] = value;
+      expect(stringProperty.exists(context1), isTrue,
+          reason: 'Value should exist after being set');
+
+      stringProperty.clear(context1);
+
+      expect(stringProperty.exists(context1), isFalse,
+          reason: 'Value should not exist after clear');
+    });
+
+    test(
+        'Given a ContextProperty for int and a RequestContext, '
+        'when an int value is set, retrieved, its existence checked, and then cleared, '
+        'then all operations behave as expected', () {
+      final numberProperty = ContextProperty<int>('numberProperty');
+      const value = 42;
+
+      numberProperty[context1] = value;
+      expect(numberProperty[context1], value);
+      expect(numberProperty.getOrNull(context1), value);
+      expect(numberProperty.exists(context1), isTrue);
+
+      numberProperty.clear(context1);
+      expect(numberProperty.exists(context1), isFalse);
+    });
+
+    test(
+        'Given a ContextProperty for a custom User object and a RequestContext, '
+        'when a User instance is set, retrieved, its existence checked, and then cleared, '
+        'then all operations behave as expected and the same instance is retrieved',
+        () {
+      final userProperty = ContextProperty<User>('userProperty');
+      final user = User('Test User', 30);
+
+      userProperty[context1] = user;
+      expect(userProperty[context1], same(user));
+      expect(userProperty.getOrNull(context1), same(user));
+      expect(userProperty.exists(context1), isTrue);
+
+      userProperty.clear(context1);
+      expect(userProperty.exists(context1), isFalse);
+    });
+  });
+}
+
+// Dummy User class for testing with custom objects
+class User {
+  final String name;
+  final int age;
+  User(this.name, this.age);
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is User &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          age == other.age;
+
+  @override
+  int get hashCode => name.hashCode ^ age.hashCode;
+
+  @override
+  String toString() {
+    return 'User{name: $name, age: $age}';
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces `ContextProperty`, a utility for managing request-scoped data. It uses an `Expando` internally to associate data with a `RequestContext`'s token, ensuring data isolation between requests.

### Key changes
- Added `ContextProperty<T>` class in `lib/src/middleware/context_property.dart`.
- Refactored `routing_middleware.dart` to use `ContextProperty` for `_pathParametersStorage`.
- Added tests for `ContextProperty` in `test/src/middleware/context_property_test.dart`.
- Exported `ContextProperty` from `lib/relic.dart`.

## Related Issues
- Closes: ?

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new utility for managing request-scoped data, allowing safe storage and retrieval of contextual information within middleware and request handling.
- **Bug Fixes**
  - Improved isolation of request-specific data to prevent unintended data sharing between requests.
- **Tests**
  - Added comprehensive tests to ensure correct behavior, type safety, and isolation of request-scoped data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->