### PR TITLE
feat: X-Forwarded-for typed header

### DIFF
--- a/lib/src/headers/extension/string_list_extensions.dart
+++ b/lib/src/headers/extension/string_list_extensions.dart
@@ -17,12 +17,17 @@ extension StringListExtensions on Iterable<String> {
   Iterable<String> splitTrimAndFilterUnique({
     final String separator = ',',
     final bool emptyCheck = true,
-  }) {
-    final filtered = expand((final element) => element.split(separator))
-        .map((final el) => el.trim())
-        .where((final e) => !emptyCheck || e.isNotEmpty);
-    return LinkedHashSet<String>.from(filtered);
-  }
+  }) =>
+      LinkedHashSet<String>.from(
+          splitAndTrim(separator: separator, emptyCheck: emptyCheck));
+
+  Iterable<String> splitAndTrim({
+    final String separator = ',',
+    final bool emptyCheck = true,
+  }) =>
+      expand((final element) => element.split(separator))
+          .map((final el) => el.trim())
+          .where((final e) => !emptyCheck || e.isNotEmpty);
 }
 
 extension StringExtensions on String {

--- a/lib/src/headers/headers.dart
+++ b/lib/src/headers/headers.dart
@@ -1,9 +1,10 @@
 import 'dart:collection';
 
 import 'package:http_parser/http_parser.dart';
-import '../../relic.dart';
 
+import '../../relic.dart';
 import 'codecs/common_types_codecs.dart';
+import 'typed/headers/x_forwarded_for_header.dart';
 
 part 'mutable_headers.dart';
 
@@ -65,7 +66,7 @@ class Headers extends HeadersBase {
   static const ifUnmodifiedSince =
       HeaderAccessor(Headers.ifUnmodifiedSinceHeader, dateTimeHeaderCodec);
 
-// General Headers
+  /// General Headers
   static const origin = HeaderAccessor(Headers.originHeader, uriHeaderCodec);
 
   static const server = HeaderAccessor(Headers.serverHeader, stringHeaderCodec);
@@ -134,7 +135,6 @@ class Headers extends HeadersBase {
       HeaderAccessor(Headers.upgradeHeader, UpgradeHeader.codec);
 
   /// Response Headers
-
   static const location =
       HeaderAccessor(Headers.locationHeader, uriHeaderCodec);
 
@@ -191,7 +191,6 @@ class Headers extends HeadersBase {
       Headers.contentDispositionHeader, ContentDispositionHeader.codec);
 
   /// Common Headers (Used in Both Requests and Responses)
-
   static const accept =
       HeaderAccessor(Headers.acceptHeader, AcceptHeader.codec);
 
@@ -208,7 +207,6 @@ class Headers extends HeadersBase {
       HeaderAccessor(Headers.setCookieHeader, SetCookieHeader.codec);
 
   /// Security and Modern Headers
-
   static const strictTransportSecurity = HeaderAccessor(
       Headers.strictTransportSecurityHeader,
       StrictTransportSecurityHeader.codec);
@@ -247,6 +245,9 @@ class Headers extends HeadersBase {
 
   static const forwarded =
       HeaderAccessor(Headers.forwardedHeader, ForwardedHeader.codec);
+
+  static const xForwardedFor =
+      HeaderAccessor(Headers.xForwardedForHeader, XForwardedForHeader.codec);
 
   static const crossOriginResourcePolicy = HeaderAccessor(
       Headers.crossOriginResourcePolicyHeader,
@@ -304,6 +305,7 @@ class Headers extends HeadersBase {
     secFetchMode,
     secFetchSite,
     forwarded,
+    xForwardedFor,
   };
 
   static const _responseOnly = {
@@ -364,6 +366,7 @@ class Headers extends HeadersBase {
   static const accessControlRequestMethodHeader =
       'access-control-request-method';
   static const forwardedHeader = 'forwarded';
+  static const xForwardedForHeader = 'x-forwarded-for';
 
   /// Response Headers
   static const accessControlAllowCredentialsHeader =

--- a/lib/src/headers/typed/headers/x_forwarded_for_header.dart
+++ b/lib/src/headers/typed/headers/x_forwarded_for_header.dart
@@ -1,0 +1,55 @@
+import 'package:collection/collection.dart';
+import '../../../../relic.dart';
+import '../../extension/string_list_extensions.dart';
+
+/// Typed representation of the `X-Forwarded-For` (XFF) HTTP header.
+///
+/// This header is a de-facto standard for identifying the originating IP address
+/// of a client connecting to a web server through an HTTP proxy or a load balancer.
+/// It typically contains a comma-separated list of IP addresses, with the leftmost
+/// being the original client and each subsequent proxy adding the IP address of the
+/// incoming request.
+///
+/// See [MDN Web Docs: X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+/// and [RFC 7239, Section 5.2](https://tools.ietf.org/html/rfc7239#section-5.2).
+final class XForwardedForHeader {
+  /// The list of IP addresses or "unknown" placeholders.
+  /// The order is significant: the first IP is the original client,
+  /// subsequent IPs are proxies.
+  final List<String> addresses;
+
+  /// Creates an [XForwardedForHeader] with the given list of addresses.
+  XForwardedForHeader(final Iterable<String> addresses)
+      : addresses = List.unmodifiable(addresses);
+
+  /// Parses the `X-Forwarded-For` header values into an [XForwardedForHeader].
+  factory XForwardedForHeader.parse(final Iterable<String> values) {
+    final parsedAddresses = values.splitAndTrim(); // 'unknown' may repeat
+    if (parsedAddresses.isEmpty) {
+      throw const FormatException('Value cannot be empty');
+    }
+    return XForwardedForHeader(parsedAddresses);
+  }
+
+  /// The [HeaderCodec] for [XForwardedForHeader].
+  static const codec = HeaderCodec<XForwardedForHeader>(
+    XForwardedForHeader.parse,
+    __encode,
+  );
+
+  static List<String> __encode(final XForwardedForHeader value) =>
+      [value._encode()];
+  String _encode() => addresses.join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is XForwardedForHeader &&
+          const ListEquality<String>().equals(addresses, other.addresses);
+
+  @override
+  int get hashCode => const ListEquality<String>().hash(addresses);
+
+  @override
+  String toString() => 'XForwardedForHeader(addresses: $addresses)';
+}

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -176,6 +176,7 @@ void main() {
       Headers.userAgent,
       Headers.vary,
       Headers.via,
+      Headers.xForwardedFor,
       Headers.xPoweredBy,
     }),
   );

--- a/test/headers/typed/x_forwarded_for_header_test.dart
+++ b/test/headers/typed/x_forwarded_for_header_test.dart
@@ -1,0 +1,252 @@
+import 'package:relic/src/headers/typed/headers/x_forwarded_for_header.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('XForwardedForHeader', () {
+    group('parse', () {
+      test(
+          'Given a single IP address, '
+          'when parsed, '
+          'then addresses list contains that IP', () {
+        final values = ['192.0.2.43'];
+        final expectedAddresses = ['192.0.2.43'];
+
+        final header = XForwardedForHeader.parse(values);
+
+        expect(header.addresses, equals(expectedAddresses));
+      });
+
+      test(
+          'Given multiple IP addresses comma-separated, '
+          'when parsed, '
+          'then addresses list contains all IPs in order', () {
+        final values = ['192.0.2.43, 198.51.100.10, 203.0.113.60'];
+        final expectedAddresses = [
+          '192.0.2.43',
+          '198.51.100.10',
+          '203.0.113.60'
+        ];
+
+        final header = XForwardedForHeader.parse(values);
+
+        expect(header.addresses, orderedEquals(expectedAddresses));
+      });
+
+      test(
+          'Given multiple IP addresses with varying spacing, '
+          'when parsed, '
+          'then addresses are trimmed and correct', () {
+        final values = ['192.0.2.43,198.51.100.10  , 203.0.113.60'];
+        final expectedAddresses = [
+          '192.0.2.43',
+          '198.51.100.10',
+          '203.0.113.60'
+        ];
+
+        final header = XForwardedForHeader.parse(values);
+
+        expect(header.addresses, orderedEquals(expectedAddresses));
+      });
+
+      test(
+          'Given IP addresses including "unknown", '
+          'when parsed, '
+          'then "unknown" is included as an address', () {
+        final values = ['unknown, 192.0.2.43, unknown'];
+        final expectedAddresses = ['unknown', '192.0.2.43', 'unknown'];
+
+        final header = XForwardedForHeader.parse(values);
+
+        expect(header.addresses, orderedEquals(expectedAddresses));
+      });
+
+      test(
+          'Given multiple header lines, '
+          'when parsed, '
+          'then addresses from all lines are combined and split correctly', () {
+        final values = ['192.0.2.43, 198.51.100.10', '203.0.113.60, 10.0.0.1'];
+        final expectedAddresses = [
+          '192.0.2.43',
+          '198.51.100.10',
+          '203.0.113.60',
+          '10.0.0.1'
+        ];
+
+        final header = XForwardedForHeader.parse(values);
+
+        expect(header.addresses, orderedEquals(expectedAddresses));
+      });
+
+      test(
+          'Given empty input values, '
+          'when parsed, '
+          'then it throws a FormatException', () {
+        final values = <String>[];
+
+        expect(() => XForwardedForHeader.parse(values),
+            throwsA(isA<FormatException>()));
+      });
+
+      test(
+          'Given input values with only commas or whitespace, '
+          'when parsed, '
+          'then it throws a FormatException', () {
+        final values = [', ,', '   ', ' , '];
+
+        expect(() => XForwardedForHeader.parse(values),
+            throwsA(isA<FormatException>()));
+      });
+
+      test(
+          'Given input values that are empty strings, '
+          'when parsed, '
+          'then it throws a FormatException', () {
+        // This case assumes that if X-Forwarded-For header is present
+        // with an empty string value (e.g., X-Forwarded-For: ),
+        // it's a malformed header. This may be controversial?
+        final values = [''];
+
+        expect(() => XForwardedForHeader.parse(values),
+            throwsA(isA<FormatException>()));
+      });
+
+      test(
+          'Given input values that are multiple empty strings, '
+          'when parsed, '
+          'then it throws a FormatException', () {
+        final values = [
+          '',
+          ''
+        ]; // Represents multiple X-Forwarded-For: headers that are empty
+
+        expect(() => XForwardedForHeader.parse(values),
+            throwsA(isA<FormatException>()));
+      });
+
+      test(
+          'Given IPv6 addresses and obfuscated identifiers, '
+          'when parsed, '
+          'then they are treated as simple strings', () {
+        final values = ['[2001:db8::1], _hidden, 192.0.2.43:8080'];
+        final expectedAddresses = [
+          '[2001:db8::1]',
+          '_hidden',
+          '192.0.2.43:8080'
+        ]; // XFF doesn't parse ports, it's just a string
+
+        final header = XForwardedForHeader.parse(values);
+
+        expect(header.addresses, orderedEquals(expectedAddresses));
+      });
+    });
+
+    group('Immutability', () {
+      test(
+          'Given an XForwardedForHeader, '
+          'when attempting to modify addresses list, '
+          'then it should throw an UnsupportedError', () {
+        final header = XForwardedForHeader(['192.0.2.43']);
+
+        expect(() => header.addresses.add('another-ip'),
+            throwsA(isA<UnsupportedError>()));
+        expect(
+            () => header.addresses.clear(), throwsA(isA<UnsupportedError>()));
+      });
+    });
+
+    group('Equality and hashCode', () {
+      test(
+          'Given two XForwardedForHeader instances with the same addresses, '
+          'when compared, '
+          'then they are equal and have the same hashCode', () {
+        final addresses = ['192.0.2.43', '198.51.100.10'];
+        final header1 =
+            XForwardedForHeader(List.of(addresses)); // Ensure new list
+        final header2 =
+            XForwardedForHeader(List.of(addresses)); // Ensure new list
+
+        expect(header1, equals(header2));
+        expect(header1.hashCode, equals(header2.hashCode));
+      });
+
+      test(
+          'Given two XForwardedForHeader instances with different addresses, '
+          'when compared, '
+          'then they are not equal', () {
+        final header1 = XForwardedForHeader(['192.0.2.43', '198.51.100.10']);
+        final header2 = XForwardedForHeader(['192.0.2.43', '203.0.113.60']);
+
+        expect(header1, isNot(equals(header2)));
+      });
+
+      test(
+          'Given two XForwardedForHeader instances with addresses in different order, '
+          'when compared, '
+          'then they are not equal', () {
+        final header1 = XForwardedForHeader(['192.0.2.43', '198.51.100.10']);
+        final header2 = XForwardedForHeader(['198.51.100.10', '192.0.2.43']);
+
+        expect(header1, isNot(equals(header2)));
+      });
+
+      test(
+          'Given an XForwardedForHeader and a different type, '
+          'when compared, '
+          'then they are not equal', () {
+        final header = XForwardedForHeader(['192.0.2.43']);
+        const otherObject = 'not-a-header';
+
+        // ignore: unrelated_type_equality_checks
+        expect(header, isNot(equals(otherObject)));
+      });
+    });
+
+    group('codec', () {
+      test(
+          'Given an XForwardedForHeader, '
+          'when encoded using codec, '
+          'then it produces the correct string list', () {
+        final header =
+            XForwardedForHeader(['192.0.2.43', '198.51.100.10', 'unknown']);
+        final expectedStrings = ['192.0.2.43, 198.51.100.10, unknown'];
+
+        final encoded = XForwardedForHeader.codec.encode(header);
+
+        expect(encoded, orderedEquals(expectedStrings));
+      });
+
+      test(
+          'Given a list of strings, '
+          'when parsed using codec, '
+          'then it produces the correct XForwardedForHeader', () {
+        final values = ['192.0.2.43, 198.51.100.10', 'unknown, 10.0.0.1'];
+        final expectedHeader = XForwardedForHeader(
+            ['192.0.2.43', '198.51.100.10', 'unknown', '10.0.0.1']);
+
+        final parsed = XForwardedForHeader.codec.decode(values);
+
+        expect(parsed, equals(expectedHeader));
+      });
+
+      test(
+          'Given an empty list of strings, '
+          'when parsed using codec, '
+          'then it throws a FormatException', () {
+        final values = <String>[];
+
+        expect(() => XForwardedForHeader.codec.decode(values),
+            throwsA(isA<FormatException>()));
+      });
+
+      test(
+          'Given a list of strings that result in no valid addresses after parsing, '
+          'when parsed using codec, '
+          'then it throws a FormatException', () {
+        final values = [', ', '  ', ',,']; // Values that would be filtered out
+
+        expect(() => XForwardedForHeader.codec.decode(values),
+            throwsA(isA<FormatException>()));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description
feat: Add typed header for X-Forwarded-For

Introduces `XForwardedForHeader` for typed access to the `X-Forwarded-For` HTTP header.
Includes:
- Parsing and encoding logic for comma-separated IP addresses.
- Integration into `Headers` class and relevant test suites.
- Refactoring of string list splitting extensions for clarity.

## Related Issues
- Closes: ?

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.

## Additional Notes
To be used as fallback, when `Forwarded` header not set in serverpod.
