### PR TITLE
fix: Missing convienience getters and setter for Headers.xForwardedFor

### DIFF
--- a/lib/src/headers/standard_headers_extensions.dart
+++ b/lib/src/headers/standard_headers_extensions.dart
@@ -1,5 +1,6 @@
 import '../method/request_method.dart';
 import 'headers.dart';
+import 'typed/headers/x_forwarded_for_header.dart';
 import 'typed/typed_headers.dart';
 
 extension HeadersEx on Headers {
@@ -87,6 +88,7 @@ extension HeadersEx on Headers {
   CrossOriginOpenerPolicyHeader? get crossOriginOpenerPolicy =>
       Headers.crossOriginOpenerPolicy[this]();
   ForwardedHeader? get forwarded => Headers.forwarded[this]();
+  XForwardedForHeader? get xForwardedFor => Headers.xForwardedFor[this]();
 }
 
 extension MutableHeadersEx on MutableHeaders {
@@ -199,6 +201,8 @@ extension MutableHeadersEx on MutableHeaders {
       Headers.crossOriginOpenerPolicy[this].set(value);
   set forwarded(final ForwardedHeader? value) =>
       Headers.forwarded[this].set(value);
+  set xForwardedFor(final XForwardedForHeader? value) =>
+      Headers.xForwardedFor[this].set(value);
 
   // We have to repeat these read props, since dart cannot have getter and setter defined on two different
   // classes as extensions
@@ -286,4 +290,5 @@ extension MutableHeadersEx on MutableHeaders {
   CrossOriginOpenerPolicyHeader? get crossOriginOpenerPolicy =>
       Headers.crossOriginOpenerPolicy[this]();
   ForwardedHeader? get forwarded => Headers.forwarded[this]();
+  XForwardedForHeader? get xForwardedFor => Headers.xForwardedFor[this]();
 }

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -1,4 +1,5 @@
 import 'package:relic/relic.dart';
+import 'package:relic/src/headers/typed/headers/x_forwarded_for_header.dart';
 import 'package:test/test.dart';
 
 import '../util/test_util.dart';
@@ -264,6 +265,8 @@ void main() {
       Headers.via: (final h) => h.via,
       Headers.wwwAuthenticate: (final h) => h.wwwAuthenticate,
       Headers.xPoweredBy: (final h) => h.xPoweredBy,
+      Headers.forwarded: (final h) => h.forwarded,
+      Headers.xForwardedFor: (final h) => h.xForwardedFor,
     }.entries,
   );
 
@@ -350,6 +353,8 @@ void main() {
       Headers.via: (final h) => h.via,
       Headers.wwwAuthenticate: (final h) => h.wwwAuthenticate,
       Headers.xPoweredBy: (final h) => h.xPoweredBy,
+      Headers.forwarded: (final h) => h.forwarded,
+      Headers.xForwardedFor: (final h) => h.xForwardedFor,
     }.entries,
   );
 
@@ -439,6 +444,8 @@ void main() {
       Headers.via: (final h) => h.via = null,
       Headers.wwwAuthenticate: (final h) => h.wwwAuthenticate = null,
       Headers.xPoweredBy: (final h) => h.xPoweredBy = null,
+      Headers.forwarded: (final h) => h.forwarded = null,
+      Headers.xForwardedFor: (final h) => h.xForwardedFor = null,
     }.entries,
   );
 
@@ -558,6 +565,9 @@ void main() {
       Headers.wwwAuthenticate: (final h) => h.wwwAuthenticate =
           const AuthenticationHeader(scheme: '', parameters: []),
       Headers.xPoweredBy: (final h) => h.xPoweredBy = 'null',
+      Headers.forwarded: (final h) => h.forwarded = ForwardedHeader([]),
+      Headers.xForwardedFor: (final h) =>
+          h.xForwardedFor = XForwardedForHeader([]),
     }.entries,
   );
 }


### PR DESCRIPTION
## Description

- Adding getter and setter for `xForwardedFor` in `HeadersEx` and `MutableHeadersEx` extensions.
- Including tests for `xForwardedFor` (and `forwarded`) in `header_test.dart` to ensure proper functionality for parsing and setting.

## Related Issues
- Closes: ?

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.

## Additional Notes
Forgotten is previous PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for accessing and modifying the X-Forwarded-For HTTP header through header extensions.

- **Tests**
  - Expanded test coverage to include reading and writing of the X-Forwarded-For and Forwarded headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->