### PR TITLE
fix: Handle ':' in BasicAuthorizationHeader parser correctly

### DIFF
--- a/lib/src/headers/typed/headers/authorization_header.dart
+++ b/lib/src/headers/typed/headers/authorization_header.dart
@@ -124,6 +124,9 @@ final class BasicAuthorizationHeader extends AuthorizationHeader {
     if (username.isEmpty) {
       throw const FormatException('Username cannot be empty');
     }
+    if (username.contains(':')) {
+      throw const FormatException('Username cannot contain ":"');
+    }
     if (password.isEmpty) {
       throw const FormatException('Password cannot be empty');
     }
@@ -147,10 +150,10 @@ final class BasicAuthorizationHeader extends AuthorizationHeader {
 
     try {
       final decoded = utf8.decode(base64Decode(base64Part));
-      final parts = decoded.split(':');
+      final split = decoded.indexOf(':');
       return BasicAuthorizationHeader(
-        username: parts[0],
-        password: parts[1],
+        username: decoded.substring(0, split),
+        password: decoded.substring(split + 1),
       );
     } catch (e) {
       throw const FormatException('Invalid basic token format');

--- a/test/headers/typed/authorization_header_test.dart
+++ b/test/headers/typed/authorization_header_test.dart
@@ -137,7 +137,7 @@ void main() {
         'when a Basic token is passed then it should parse the credentials '
         'correctly',
         () async {
-          final credentials = base64Encode(utf8.encode('user:pass'));
+          final credentials = base64Encode(utf8.encode('user:pass:word'));
           final headers = await getServerRequestHeaders(
             server: server,
             touchHeaders: (final h) => h.authorization,
@@ -148,7 +148,7 @@ void main() {
             headers.authorization,
             isA<BasicAuthorizationHeader>()
                 .having((final auth) => auth.username, 'username', 'user')
-                .having((final auth) => auth.password, 'password', 'pass'),
+                .having((final auth) => auth.password, 'password', 'pass:word'),
           );
         },
       );


### PR DESCRIPTION
## Description

This change corrects the parsing of `BasicAuthorizationHeader` to support colons in the password. It now splits the username and password only at the first colon and adds a validation to prevent colons in the username. The corresponding tests have been updated to reflect this fix.

## Related Issues
- Fixes: #111

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.
