### PR TITLE
fix: Export bindHttpServer in io_adapter.dart

### DIFF
--- a/lib/io_adapter.dart
+++ b/lib/io_adapter.dart
@@ -1,2 +1,3 @@
+export 'src/adapter/io/bind_http_server.dart';
 export 'src/adapter/io/io_adapter.dart';
 export 'src/adapter/io/io_serve.dart';


### PR DESCRIPTION
## Description
Fixes an oversight, where the `bindHttpServer` convenience function wasn't exported from `io_adapter.dart`.

## Related Issues
- Closes: ?

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [ x I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [ ] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.
