### PR TITLE
fix: Update imports README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ See `relic/example/example.dart` for a runnable example. The following code demo
 ```dart
 import 'dart:io';
 
+import 'package:relic/io_adapter.dart';
 import 'package:relic/relic.dart';
-import 'package:relic/src/adapter/context.dart';
-import 'package:relic/src/middleware/routing_middleware.dart';
 
 /// A simple 'Hello World' server
 Future<void> main() async {


### PR DESCRIPTION
When running the example with version 0.4.1 I had to change the imports slightly from the suggested ones in the README.