### PR TITLE
refactor: Rename withResponse to respond (matches connect/hijack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ResponseContext hello(final RequestContext ctx) {
   final name = ctx.pathParameters[#name];
   final age = int.parse(ctx.pathParameters[#age]!);
 
-  return (ctx as RespondableContext).withResponse(Response.ok(
+  return (ctx as RespondableContext).respond(Response.ok(
       body: Body.fromString('Hello $name! To think you are $age years old.')));
 }
 ```

--- a/example/example.dart
+++ b/example/example.dart
@@ -30,6 +30,6 @@ ResponseContext hello(final NewContext ctx) {
   final name = ctx.pathParameters[#name];
   final age = int.parse(ctx.pathParameters[#age]!);
 
-  return ctx.withResponse(Response.ok(
+  return ctx.respond(Response.ok(
       body: Body.fromString('Hello $name! To think you are $age years old.')));
 }

--- a/lib/src/adapter/context.dart
+++ b/lib/src/adapter/context.dart
@@ -38,7 +38,7 @@ abstract interface class RespondableContext
   /// Transitions the context to a state where a response has been associated.
   ///
   /// Takes a [Response] object [r] and returns a [ResponseContext].
-  ResponseContext withResponse(final Response r);
+  ResponseContext respond(final Response r);
 }
 
 /// An interface for request contexts that allow hijacking the underlying connection.
@@ -53,7 +53,7 @@ abstract interface class HijackableContext implements _RequestContextInterface {
 /// Represents the initial state of a request context before it has been
 /// handled (i.e., before a response is generated or the connection is hijacked).
 ///
-/// This context can transition to either a [ResponseContext] via [withResponse],
+/// This context can transition to either a [ResponseContext] via [respond],
 /// a [HijackContext] via [hijack], or a [ConnectContext] via [connect].
 final class NewContext extends RequestContext
     implements RespondableContext, HijackableContext {
@@ -73,7 +73,7 @@ final class NewContext extends RequestContext
       ConnectContext._(request, token, c);
 
   @override
-  ResponseContext withResponse(final Response r) =>
+  ResponseContext respond(final Response r) =>
       ResponseContext._(request, token, r);
 }
 
@@ -94,7 +94,7 @@ final class ResponseContext extends HandledContext
   ResponseContext._(super.request, super.token, this.response) : super._();
 
   @override
-  ResponseContext withResponse(final Response r) =>
+  ResponseContext respond(final Response r) =>
       ResponseContext._(request, token, r);
 }
 

--- a/lib/src/handler/handler.dart
+++ b/lib/src/handler/handler.dart
@@ -60,11 +60,11 @@ typedef Responder = FutureOr<Response> Function(Request);
 ///
 /// The input [NewContext] to the generated [Handler] must be a
 /// [RespondableContext] (i.e., capable of producing a response) for the
-/// `withResponse` call to succeed. The handler ensures the resulting context is
+/// `respond` call to succeed. The handler ensures the resulting context is
 /// a [ResponseContext].
 Handler respondWith(final Responder responder) {
   return (final ctx) async {
-    return ctx.withResponse(await responder(ctx.request));
+    return ctx.respond(await responder(ctx.request));
   };
 }
 

--- a/lib/src/io/static/static_handler.dart
+++ b/lib/src/io/static/static_handler.dart
@@ -138,7 +138,7 @@ Future<ResponseContext> _serveFile(
 
   // Handle conditional requests
   final conditionalResponse = _checkConditionalHeaders(ctx, fileInfo, headers);
-  if (conditionalResponse != null) return ctx.withResponse(conditionalResponse);
+  if (conditionalResponse != null) return ctx.respond(conditionalResponse);
 
   // Handle range requests
   final rangeHeader = ctx.request.headers.range;
@@ -157,7 +157,7 @@ bool _isMethodAllowed(final RequestMethod method) {
 
 /// Returns a 405 Method Not Allowed response.
 ResponseContext _methodNotAllowedResponse(final NewContext ctx) {
-  return ctx.withResponse(Response(
+  return ctx.respond(Response(
     HttpStatus.methodNotAllowed,
     headers: Headers.build((final mh) => mh.allow = [
           RequestMethod.get,
@@ -296,7 +296,7 @@ ResponseContext _serveFullFile(
   final Headers headers,
   final RequestMethod method,
 ) {
-  return ctx.withResponse(Response.ok(
+  return ctx.respond(Response.ok(
     headers: headers,
     body: method == RequestMethod.head
         ? null
@@ -316,12 +316,12 @@ ResponseContext _serveSingleRange(
 
   // If range is invalid
   if (start == end) {
-    return ctx.withResponse(Response(416, headers: headers));
+    return ctx.respond(Response(416, headers: headers));
   }
 
   final length = end - start;
 
-  return ctx.withResponse(Response(
+  return ctx.respond(Response(
     HttpStatus.partialContent,
     headers: headers.transform((final mh) => mh
       ..contentRange = ContentRangeHeader(
@@ -365,7 +365,7 @@ Future<ResponseContext> _serveMultipleRanges(
 
   unawaited(controller.close());
 
-  return ctx.withResponse(Response(
+  return ctx.respond(Response(
     HttpStatus.partialContent,
     headers: headers.transform((final mh) => mh
       ..contentLength = totalLength

--- a/lib/src/middleware/middleware.dart
+++ b/lib/src/middleware/middleware.dart
@@ -53,7 +53,7 @@ Middleware createMiddleware({
   return (final innerHandler) {
     return (final ctx) async {
       var response = await onRequest!(ctx.request);
-      if (response != null) return ctx.withResponse(response);
+      if (response != null) return ctx.respond(response);
       late ResponseContext responseCtx;
       try {
         final newCtx = await innerHandler(ctx);
@@ -61,12 +61,12 @@ Middleware createMiddleware({
         responseCtx = newCtx;
       } catch (e, s) {
         if (onError != null) {
-          return ctx.withResponse(await onError(e, s));
+          return ctx.respond(await onError(e, s));
         }
         rethrow;
       }
       response = await onResponse!(responseCtx.response);
-      return responseCtx.withResponse(response);
+      return responseCtx.respond(response);
     };
   };
 }

--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -121,7 +121,7 @@ class RelicServer {
         return switch (handledCtx) {
           final ResponseContext rc =>
             // If the response doesn't have a powered-by or date header, add the default ones
-            rc.withResponse(
+            rc.respond(
               rc.response.copyWith(headers: rc.response.headers.transform(
                 (final mh) {
                   mh.xPoweredBy ??= poweredByHeader;
@@ -138,7 +138,7 @@ class RelicServer {
           'Error parsing request headers.\n$error',
           stackTrace,
         );
-        return ctx.withResponse(Response.badRequest(
+        return ctx.respond(Response.badRequest(
           body: Body.fromString(error.httpResponseBody),
         ));
       }

--- a/test/middleware/routing_middleware_test.dart
+++ b/test/middleware/routing_middleware_test.dart
@@ -34,7 +34,7 @@ void main() {
         Map<Symbol, String>? capturedParams;
         Future<HandledContext> testHandler(final NewContext ctx) async {
           capturedParams = ctx.pathParameters;
-          return ctx.withResponse(Response(200));
+          return ctx.respond(Response(200));
         }
 
         router.add(Method.get, '/users/:id', testHandler);
@@ -57,7 +57,7 @@ void main() {
         Map<Symbol, String>? capturedParams;
         Future<ResponseContext> testHandler(final NewContext ctx) async {
           capturedParams = ctx.pathParameters;
-          return ctx.withResponse(Response(200));
+          return ctx.respond(Response(200));
         }
 
         router.add(Method.get, '/users', testHandler);
@@ -82,7 +82,7 @@ void main() {
         Future<ResponseContext> nextHandler(final NewContext ctx) async {
           nextCalled = true;
           expect(ctx.pathParameters, isEmpty);
-          return ctx.withResponse(Response(404));
+          return ctx.respond(Response(404));
         }
 
         final initialCtx = _FakeRequest('/nonexistent').toContext(Object());
@@ -121,7 +121,7 @@ void main() {
         router1.add(Method.get, '/router1/:item', (final NewContext ctx) async {
           handler1Called = true;
           params1 = ctx.pathParameters;
-          return ctx.withResponse(Response(201));
+          return ctx.respond(Response(201));
         });
         router2.add(Method.get, '/router2/:item', respondWith((final _) {
           handler2Called = true;
@@ -157,7 +157,7 @@ void main() {
         router2.add(Method.get, '/router2/:data', (final NewContext ctx) async {
           handler2Called = true;
           params2 = ctx.pathParameters;
-          return ctx.withResponse(Response(202));
+          return ctx.respond(Response(202));
         });
 
         final pipelineHandler =
@@ -222,7 +222,7 @@ void main() {
             (final NewContext ctx) async {
           nestedHandlerCalled = true;
           capturedParams = ctx.pathParameters;
-          return ctx.withResponse(Response(200));
+          return ctx.respond(Response(200));
         });
 
         // Attach nestedRouter to mainRouter under /resource/:resourceId
@@ -263,7 +263,7 @@ void main() {
             (final NewContext ctx) async {
           deeplyNestedHandlerCalled = true;
           capturedParams = ctx.pathParameters;
-          return ctx.withResponse(Response(200));
+          return ctx.respond(Response(200));
         });
 
         // Attach leafRouter to intermediateRouter under a parameterized path
@@ -305,7 +305,7 @@ void main() {
         subRouter.add(Method.get, '/:id/end', (final NewContext ctx) async {
           // sub-router uses :id
           capturedParams = ctx.pathParameters;
-          return ctx.withResponse(Response(200));
+          return ctx.respond(Response(200));
         });
 
         mainRouter.attach('/:id/sub', subRouter); // main router uses :id

--- a/test/static/test_util.dart
+++ b/test/static/test_util.dart
@@ -43,7 +43,7 @@ Handler _rootHandler(final String? path, final Handler handler) {
     final ctx = requestCtx as RespondableContext;
     final request = ctx.request;
     if (!_ctx.isWithin('/$path', request.requestedUri.path)) {
-      return ctx.withResponse(Response.notFound(
+      return ctx.respond(Response.notFound(
         body: Body.fromString(
           'not found',
         ),

--- a/test/util/test_util.dart
+++ b/test/util/test_util.dart
@@ -24,7 +24,7 @@ SyncHandler createSyncHandler({
   final Body? body,
 }) {
   return (final NewContext ctx) {
-    return ctx.withResponse(Response(
+    return ctx.respond(Response(
       statusCode,
       headers: headers ?? Headers.empty(),
       body: body ??


### PR DESCRIPTION
## Description

Rename `RespondableContext.withResponse` to `RespondableContext.respond `. This aligns better with name of the member used, when setting up web socket connections `NewContext.connect`.

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [ ] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [x] Includes breaking changes.
- [ ] No breaking changes.

This PR renames a public method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed the context API from withResponse(...) to respond(...). Update any handlers, middleware, and static file responses to use ctx.respond(...). No behavior changes.

- Documentation
  - Updated references to reflect the respond(...) API.

- Tests
  - Updated test suites to use respond(...) consistently.

- Chores
  - Internal codebase aligned to the new respond(...) naming across modules for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->