### PR TITLE
fix: Host header is not a Uri. Introduce an RFC3986 compliant HostHeader class

### DIFF
--- a/lib/src/headers/exception/header_exception.dart
+++ b/lib/src/headers/exception/header_exception.dart
@@ -35,16 +35,22 @@ sealed class HeaderException implements Exception {
 /// The error details, including the header type and description, are also
 /// available in a formatted string for use in HTTP responses via [httpResponseBody].
 class InvalidHeaderException extends HeaderException {
+  /// The raw header values that caused the error.
+  ///
+  /// This can be useful for debugging purposes to see what values were provided.
+  final Iterable<String> raw;
+
   /// Creates an [InvalidHeaderException] with a [description] describing the error
   /// and the [headerType] indicating the problematic header.
-  const InvalidHeaderException(super.description, {required super.headerType});
+  const InvalidHeaderException(super.description,
+      {required super.headerType, this.raw = const []});
 
   @override
   String get httpResponseBody => "Invalid '$headerType' header: $description";
 
   @override
   String toString() =>
-      'InvalidHeaderException(description: $description, headerType: $headerType)';
+      'InvalidHeaderException(description: $description, headerType: $headerType, raw: $raw)';
 }
 
 /// Exception thrown when a required HTTP header is missing.

--- a/lib/src/headers/headers.dart
+++ b/lib/src/headers/headers.dart
@@ -75,7 +75,7 @@ class Headers extends HeadersBase {
   /// Request Headers
   static const from = HeaderAccessor(Headers.fromHeader, FromHeader.codec);
 
-  static const host = HeaderAccessor(Headers.hostHeader, uriHeaderCodec);
+  static const host = HeaderAccessor(Headers.hostHeader, HostHeader.codec);
 
   static const acceptEncoding =
       HeaderAccessor(Headers.acceptEncodingHeader, AcceptEncodingHeader.codec);

--- a/lib/src/headers/standard_headers_extensions.dart
+++ b/lib/src/headers/standard_headers_extensions.dart
@@ -12,7 +12,7 @@ extension HeadersEx on Headers {
   String? get server => Headers.server[this]();
   List<String>? get via => Headers.via[this]();
   FromHeader? get from => Headers.from[this]();
-  Uri? get host => Headers.host[this]();
+  HostHeader? get host => Headers.host[this]();
   AcceptEncodingHeader? get acceptEncoding => Headers.acceptEncoding[this]();
   AcceptLanguageHeader? get acceptLanguage => Headers.acceptLanguage[this]();
   List<String>? get accessControlRequestHeaders =>
@@ -103,7 +103,7 @@ extension MutableHeadersEx on MutableHeaders {
   set server(final String? value) => Headers.server[this].set(value);
   set via(final List<String>? value) => Headers.via[this].set(value);
   set from(final FromHeader? value) => Headers.from[this].set(value);
-  set host(final Uri? value) => Headers.host[this].set(value);
+  set host(final HostHeader? value) => Headers.host[this].set(value);
   set acceptEncoding(final AcceptEncodingHeader? value) =>
       Headers.acceptEncoding[this].set(value);
   set acceptLanguage(final AcceptLanguageHeader? value) =>
@@ -214,7 +214,7 @@ extension MutableHeadersEx on MutableHeaders {
   String? get server => Headers.server[this]();
   List<String>? get via => Headers.via[this]();
   FromHeader? get from => Headers.from[this]();
-  Uri? get host => Headers.host[this]();
+  HostHeader? get host => Headers.host[this]();
   AcceptEncodingHeader? get acceptEncoding => Headers.acceptEncoding[this]();
   AcceptLanguageHeader? get acceptLanguage => Headers.acceptLanguage[this]();
   List<String>? get accessControlRequestHeaders =>

--- a/lib/src/headers/typed/headers/host_header.dart
+++ b/lib/src/headers/typed/headers/host_header.dart
@@ -1,0 +1,56 @@
+import '../../../../relic.dart';
+
+/// Wanna-be RFC3986 compliant 'Host' header.
+final class HostHeader {
+  static const codec = HeaderCodec.single(HostHeader.parse, __encode);
+  static List<String> __encode(final HostHeader value) => [value._encode()];
+
+  final String host;
+  // TODO: This should default 80 for http, or 443 for https, but we don't have
+  // access to the scheme in HostHeader.parse. Will require some refactoring,
+  // perhaps allowing Header instances to know what Request instance they belong
+  // to. For now allow port to be null, at leave it to the client to handle.
+  final int? port;
+  HostHeader._(this.host, this.port);
+
+  factory HostHeader(final String host, [final int? port]) {
+    return HostHeader._(host.trim().toLowerCase(), port);
+  }
+
+  factory HostHeader.parse(final String value) {
+    String hostFrom(final String value) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) {
+        throw const FormatException('Value cannot be empty');
+      }
+      return trimmed;
+    }
+
+    final lastColon = value.lastIndexOf(':');
+    if (lastColon < 0) {
+      // no port, and not IPv6
+      return HostHeader(hostFrom(value), null);
+    }
+    final ipV6End = value.lastIndexOf(']');
+    if (ipV6End > lastColon) {
+      // IPv6 no port
+      return HostHeader(hostFrom(value), null);
+    }
+    final port = int.parse(value.substring(lastColon + 1));
+    return HostHeader(hostFrom(value.substring(0, lastColon)), port);
+  }
+
+  HostHeader.fromUri(final Uri uri) : this._(uri.host, uri.port);
+
+  String _encode() => port == null ? host : '$host:$port';
+
+  @override
+  bool operator ==(final Object other) {
+    if (identical(this, other)) return true;
+    if (other is! HostHeader) return false;
+    return host == other.host && port == other.port;
+  }
+
+  @override
+  int get hashCode => Object.hash(host, port);
+}

--- a/lib/src/headers/typed/headers/host_header.dart
+++ b/lib/src/headers/typed/headers/host_header.dart
@@ -10,6 +10,7 @@ final class HostHeader {
   HostHeader._(this.host, this.port);
 
   factory HostHeader(final String host, [final int? port]) {
+    RangeError.checkValueInInterval(port ?? 0, 0, 65535);
     return HostHeader._(host.trim().toLowerCase(), port);
   }
 
@@ -50,6 +51,9 @@ final class HostHeader {
       return HostHeader(host, null);
     } else {
       final port = int.parse(value.substring(lastColon + 1));
+      if (port < 0 || port > 65535) {
+        throw FormatException('Port out of range', value);
+      }
       return HostHeader(host, port);
     }
   }

--- a/lib/src/headers/typed/typed_headers.dart
+++ b/lib/src/headers/typed/typed_headers.dart
@@ -25,6 +25,7 @@ export 'headers/etag_header.dart' hide InternalEx;
 export 'headers/expect_header.dart';
 export 'headers/forwarded_header.dart';
 export 'headers/from_header.dart';
+export 'headers/host_header.dart';
 export 'headers/if_range_header.dart';
 export 'headers/permission_policy_header.dart';
 export 'headers/range_header.dart';

--- a/test/headers/basic/host_header_test.dart
+++ b/test/headers/basic/host_header_test.dart
@@ -147,6 +147,260 @@ void main() {
           expect(headers.host, isNotNull);
         },
       );
+
+      group('when IPv6 addresses are used', () {
+        test(
+          'when a valid IPv6 address in brackets is passed '
+          'then it should parse the host correctly',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:db8::1]'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host, equals(HostHeader('[2001:db8::1]', null)));
+          },
+        );
+
+        test(
+          'when a valid IPv6 address in brackets with port is passed '
+          'then it should parse both host and port correctly',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:db8::1]:8080'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(8080));
+          },
+        );
+
+        test(
+          'when an IPv6 loopback address in brackets is passed '
+          'then it should parse correctly',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[::1]'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host, equals(HostHeader('[::1]', null)));
+          },
+        );
+
+        test(
+          'when an IPv6 loopback address in brackets with port is passed '
+          'then it should parse both host and port correctly',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[::1]:3000'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(3000));
+          },
+        );
+
+        test(
+          'when IPv6 address with whitespace is passed '
+          'then it should parse correctly',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': ' [2001:db8::1] '},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host, equals(HostHeader('[2001:db8::1]', null)));
+          },
+        );
+
+        test(
+          'when full IPv6 address in brackets is passed '
+          'then it should parse correctly',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(
+                headers.host,
+                equals(HostHeader(
+                    '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]', null)));
+          },
+        );
+
+        test(
+          'when IPv6 address with double colon compression is passed '
+          'then it should parse correctly',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:db8::8a2e:370:7334]:9000'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(9000));
+          },
+        );
+
+        group('when ambiguous IPv6 addresses are used', () {
+          test(
+            'when IPv6 address ending with numbers that could be port is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[2001:db8:85a3::8a2e:370:7334]:80'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(80));
+            },
+          );
+
+          test(
+            'when IPv6 loopback with port-like ending is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[::1]:8080'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(8080));
+            },
+          );
+
+          test(
+            'when IPv6 compressed notation that could be ambiguous is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[::ffff:192.0.2.1]:443'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(443));
+            },
+          );
+
+          test(
+            'when IPv6 address with embedded IPv4 notation is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[::ffff:192.168.1.1]'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host,
+                  equals(HostHeader('[::ffff:192.168.1.1]', null)));
+            },
+          );
+
+          test(
+            'when IPv6 zero compression at end that could look like port is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[2001:db8::]:3000'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(3000));
+            },
+          );
+        });
+
+        group('when extremely ambiguous IPv6 addresses are used', () {
+          test(
+            'when IPv6 address ending exactly like common port 80 is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[fe80::1:80]:8080'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(8080));
+            },
+          );
+
+          test(
+            'when IPv6 address ending like port 443 is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[2001:db8::443]:443'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(443));
+            },
+          );
+
+          test(
+            'when minimal IPv6 with short notation is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[::1:1]:1'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(1));
+            },
+          );
+
+          test(
+            'when IPv6 with multiple consecutive numbers is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[2001:0:0:0:0:0:0:8080]'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host,
+                  equals(HostHeader('[2001:0:0:0:0:0:0:8080]', null)));
+            },
+          );
+
+          test(
+            'when IPv6 with embedded IPv4 ending in port-like numbers is passed '
+            'then it should parse correctly with brackets',
+            () async {
+              final headers = await getServerRequestHeaders(
+                server: server,
+                headers: {'host': '[64:ff9b::192.0.2.80]:80'},
+                touchHeaders: (final h) => h.host,
+              );
+
+              expect(headers.host?.port, equals(80));
+            },
+          );
+
+          // Note: Unbracketed IPv6 addresses like '::1' cannot be tested here
+          // because they cause URL parsing failures at the HTTP client level
+          // before reaching the header validation logic. This demonstrates
+          // why RFC 3986 requires brackets for all IPv6 addresses in URIs.
+        });
+      });
     },
   );
 
@@ -187,5 +441,229 @@ void main() {
         expect(headers.host, isNotNull);
       },
     );
+
+    group('when IPv6 Host headers are passed', () {
+      test(
+        'when a valid IPv6 address in brackets is passed '
+        'then it should parse correctly',
+        () async {
+          final headers = await getServerRequestHeaders(
+            server: server,
+            headers: {'host': '[2001:db8::1]'},
+            touchHeaders: (final h) => h.host,
+          );
+
+          expect(headers.host, equals(HostHeader('[2001:db8::1]', null)));
+        },
+      );
+
+      test(
+        'when a valid IPv6 address in brackets with port is passed '
+        'then it should parse both host and port correctly',
+        () async {
+          final headers = await getServerRequestHeaders(
+            server: server,
+            headers: {'host': '[::1]:3000'},
+            touchHeaders: (final h) => h.host,
+          );
+
+          expect(headers.host?.port, equals(3000));
+        },
+      );
+
+      test(
+        'when IPv6 address with whitespace is passed '
+        'then it should parse correctly',
+        () async {
+          final headers = await getServerRequestHeaders(
+            server: server,
+            headers: {'host': ' [::1]:8080 '},
+            touchHeaders: (final h) => h.host,
+          );
+
+          expect(headers.host?.port, equals(8080));
+        },
+      );
+
+      test(
+        'when full IPv6 address in brackets with port is passed '
+        'then it should parse correctly',
+        () async {
+          final headers = await getServerRequestHeaders(
+            server: server,
+            headers: {'host': '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443'},
+            touchHeaders: (final h) => h.host,
+          );
+
+          expect(headers.host?.port, equals(443));
+        },
+      );
+
+      test(
+        'when IPv6 address with double colon compression is passed '
+        'then it should parse correctly',
+        () async {
+          final headers = await getServerRequestHeaders(
+            server: server,
+            headers: {'host': '[2001:db8::8a2e:370:7334]'},
+            touchHeaders: (final h) => h.host,
+          );
+
+          expect(headers.host,
+              equals(HostHeader('[2001:db8::8a2e:370:7334]', null)));
+        },
+      );
+
+      group('when ambiguous IPv6 addresses are used', () {
+        test(
+          'when IPv6 address ending with numbers that could be port is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:db8:85a3::8a2e:370:7334]:80'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(80));
+          },
+        );
+
+        test(
+          'when IPv6 loopback with port-like ending is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[::1]:8080'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(8080));
+          },
+        );
+
+        test(
+          'when IPv6 compressed notation that could be ambiguous is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[::ffff:192.0.2.1]:443'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(443));
+          },
+        );
+
+        test(
+          'when IPv6 address with embedded IPv4 notation is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[::ffff:192.168.1.1]'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(
+                headers.host, equals(HostHeader('[::ffff:192.168.1.1]', null)));
+          },
+        );
+
+        test(
+          'when IPv6 zero compression at end that could look like port is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:db8::]:3000'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(3000));
+          },
+        );
+      });
+
+      group('when extremely ambiguous IPv6 addresses are used', () {
+        test(
+          'when IPv6 address ending exactly like common port 80 is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[fe80::1:80]:8080'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(8080));
+          },
+        );
+
+        test(
+          'when IPv6 address ending like port 443 is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:db8::443]:443'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(443));
+          },
+        );
+
+        test(
+          'when minimal IPv6 with short notation is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[::1:1]:1'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(1));
+          },
+        );
+
+        test(
+          'when IPv6 with multiple consecutive numbers is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[2001:0:0:0:0:0:0:8080]'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host,
+                equals(HostHeader('[2001:0:0:0:0:0:0:8080]', null)));
+          },
+        );
+
+        test(
+          'when IPv6 with embedded IPv4 ending in port-like numbers is passed '
+          'then it should parse correctly with brackets',
+          () async {
+            final headers = await getServerRequestHeaders(
+              server: server,
+              headers: {'host': '[64:ff9b::192.0.2.80]:80'},
+              touchHeaders: (final h) => h.host,
+            );
+
+            expect(headers.host?.port, equals(80));
+          },
+        );
+
+        // Note: Unbracketed IPv6 addresses like '::1' cannot be tested here
+        // because they cause URL parsing failures at the HTTP client level
+        // before reaching the header validation logic. This demonstrates
+        // why RFC 3986 requires brackets for all IPv6 addresses in URIs.
+      });
+    });
   });
 }

--- a/test/headers/basic/host_header_test.dart
+++ b/test/headers/basic/host_header_test.dart
@@ -4,78 +4,75 @@ library;
 import 'package:relic/relic.dart';
 import 'package:test/test.dart';
 
-import '../docs/strict_validation_docs.dart';
+import '../../util/test_util.dart';
 import '../headers_test_utils.dart';
 
 /// Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-/// About empty value test, check the [StrictValidationDocs] class for more details.
 void main() {
+  late RelicServer server;
+
+  setUp(() async {
+    server = await createServer();
+  });
+
+  tearDown(() => server.close());
+
   group(
-    'Given a Host header with the strict flag true',
+    'Given a request with a Host header',
     () {
-      late RelicServer server;
+      parameterizedTest<
+          ({
+            String description,
+            String hostValue,
+            String? expectedError,
+          })>(
+        variants: [
+          (
+            description: 'when an empty Host header is passed '
+                'then the server responds with a bad request including a message that states the header value cannot be empty',
+            hostValue: '',
+            expectedError: 'Value cannot be empty',
+          ),
+          (
+            description: 'when a Host header with an invalid format is passed '
+                'then the server responds with a bad request including a message that states the format is invalid',
+            hostValue: 'h@ttp://example.com',
+            expectedError: 'Invalid radix-10 number',
+          ),
+          (
+            description:
+                'when a Host header with an invalid port number is passed '
+                'then the server responds with a bad request including a message that states the format is invalid',
+            hostValue: 'example.com:test',
+            expectedError: null, // Just check for BadRequestException
+          ),
+          (
+            description:
+                'when a Host header with invalid port format (non-numeric) is passed '
+                'then the server responds with a bad request',
+            hostValue: '192.168.1.1:abc',
+            expectedError: null, // Just check for BadRequestException
+          ),
+        ],
+        (final testCase) => testCase.description,
+        (final testCase) async {
+          final matcher = testCase.expectedError != null
+              ? throwsA(
+                  isA<BadRequestException>().having(
+                    (final e) => e.message,
+                    'message',
+                    contains(testCase.expectedError!),
+                  ),
+                )
+              : throwsA(isA<BadRequestException>());
 
-      setUp(() async {
-        server = await createServer(strictHeaders: true);
-      });
-
-      tearDown(() => server.close());
-      test(
-        'when an empty Host header is passed then the server responds '
-        'with a bad request including a message that states the header value '
-        'cannot be empty',
-        () async {
           expect(
             getServerRequestHeaders(
               server: server,
-              headers: {'host': ''},
+              headers: {'host': testCase.hostValue},
               touchHeaders: (final h) => h.host,
             ),
-            throwsA(
-              isA<BadRequestException>().having(
-                (final e) => e.message,
-                'message',
-                contains('Value cannot be empty'),
-              ),
-            ),
-          );
-        },
-      );
-
-      test(
-        'when a Host header with an invalid format is passed '
-        'then the server responds with a bad request including a message that '
-        'states the format is invalid',
-        () async {
-          expect(
-            getServerRequestHeaders(
-              server: server,
-              headers: {'host': 'h@ttp://example.com'},
-              touchHeaders: (final h) => h.host,
-            ),
-            throwsA(
-              isA<BadRequestException>().having(
-                (final e) => e.message,
-                'message',
-                contains('Invalid radix-10 number'),
-              ),
-            ),
-          );
-        },
-      );
-
-      test(
-        'when a Host header with an invalid port number is passed '
-        'then the server responds with a bad request including a message that '
-        'states the format is invalid',
-        () async {
-          expect(
-            getServerRequestHeaders(
-              server: server,
-              headers: {'host': 'example.com:test'},
-              touchHeaders: (final h) => h.host,
-            ),
-            throwsA(isA<BadRequestException>()),
+            matcher,
           );
         },
       );
@@ -94,576 +91,258 @@ void main() {
           expect(headers, isNotNull);
         },
       );
-
-      test(
-        'when a valid Host header is passed then it should parse the host correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': 'example.com'},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host, equals(HostHeader('example.com', null)));
-        },
-      );
-
-      test(
-        'when a Host header with a port number is passed then it should parse '
-        'the port number correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': 'example.com:8080'},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host?.port, equals(8080));
-        },
-      );
-
-      test(
-        'when a Host header with extra whitespace is passed then it should parse correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': ' example.com '},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host, equals(HostHeader('example.com', null)));
-        },
-      );
-
-      test(
-        'when no Host header is passed then it should default to machine address',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host, isNotNull);
-        },
-      );
-
-      group('when IPv6 addresses are used', () {
+      group('when an invalid Host header is passed', () {
         test(
-          'when a valid IPv6 address in brackets is passed '
-          'then it should parse the host correctly',
+          'then it should return null',
           () async {
             final headers = await getServerRequestHeaders(
               server: server,
-              headers: {'host': '[2001:db8::1]'},
-              touchHeaders: (final h) => h.host,
+              touchHeaders: (final _) {},
+              headers: {'host': 'h@ttp://example.com'},
             );
 
-            expect(headers.host, equals(HostHeader('[2001:db8::1]', null)));
+            expect(Headers.host[headers].valueOrNullIfInvalid, isNull);
+            expect(() => headers.host, throwsInvalidHeader);
           },
         );
+      });
 
-        test(
-          'when a valid IPv6 address in brackets with port is passed '
-          'then it should parse both host and port correctly',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[2001:db8::1]:8080'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(8080));
-          },
-        );
-
-        test(
-          'when an IPv6 loopback address in brackets is passed '
-          'then it should parse correctly',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[::1]'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host, equals(HostHeader('[::1]', null)));
-          },
-        );
-
-        test(
-          'when an IPv6 loopback address in brackets with port is passed '
-          'then it should parse both host and port correctly',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[::1]:3000'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(3000));
-          },
-        );
-
-        test(
-          'when IPv6 address with whitespace is passed '
-          'then it should parse correctly',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': ' [2001:db8::1] '},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host, equals(HostHeader('[2001:db8::1]', null)));
-          },
-        );
-
-        test(
-          'when full IPv6 address in brackets is passed '
-          'then it should parse correctly',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(
-                headers.host,
-                equals(HostHeader(
-                    '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]', null)));
-          },
-        );
-
-        test(
-          'when IPv6 address with double colon compression is passed '
-          'then it should parse correctly',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[2001:db8::8a2e:370:7334]:9000'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(9000));
-          },
-        );
-
-        group('when ambiguous IPv6 addresses are used', () {
-          test(
-            'when IPv6 address ending with numbers that could be port is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[2001:db8:85a3::8a2e:370:7334]:80'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(80));
-            },
-          );
-
-          test(
-            'when IPv6 loopback with port-like ending is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[::1]:8080'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(8080));
-            },
-          );
-
-          test(
-            'when IPv6 compressed notation that could be ambiguous is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[::ffff:192.0.2.1]:443'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(443));
-            },
-          );
-
-          test(
-            'when IPv6 address with embedded IPv4 notation is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[::ffff:192.168.1.1]'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host,
-                  equals(HostHeader('[::ffff:192.168.1.1]', null)));
-            },
-          );
-
-          test(
-            'when IPv6 zero compression at end that could look like port is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[2001:db8::]:3000'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(3000));
-            },
-          );
-        });
-
-        group('when extremely ambiguous IPv6 addresses are used', () {
-          test(
-            'when IPv6 address ending exactly like common port 80 is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[fe80::1:80]:8080'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(8080));
-            },
-          );
-
-          test(
-            'when IPv6 address ending like port 443 is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[2001:db8::443]:443'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(443));
-            },
-          );
-
-          test(
-            'when minimal IPv6 with short notation is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[::1:1]:1'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(1));
-            },
-          );
-
-          test(
-            'when IPv6 with multiple consecutive numbers is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[2001:0:0:0:0:0:0:8080]'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host,
-                  equals(HostHeader('[2001:0:0:0:0:0:0:8080]', null)));
-            },
-          );
-
-          test(
-            'when IPv6 with embedded IPv4 ending in port-like numbers is passed '
-            'then it should parse correctly with brackets',
-            () async {
-              final headers = await getServerRequestHeaders(
-                server: server,
-                headers: {'host': '[64:ff9b::192.0.2.80]:80'},
-                touchHeaders: (final h) => h.host,
-              );
-
-              expect(headers.host?.port, equals(80));
-            },
-          );
-
+      // Basic host parsing tests
+      parameterizedTest<
+          ({
+            String description,
+            String hostValue,
+            HostHeader expectedHost,
+          })>(
+        variants: [
+          (
+            description:
+                'when a valid Host header is passed then it should parse the host correctly',
+            hostValue: 'example.com',
+            expectedHost: HostHeader('example.com', null),
+          ),
+          (
+            description:
+                'when a Host header with a port number is passed then it should parse the port number correctly',
+            hostValue: 'example.com:8080',
+            expectedHost: HostHeader('example.com', 8080),
+          ),
+          (
+            description:
+                'when a Host header with extra whitespace is passed then it should parse correctly',
+            hostValue: ' example.com ',
+            expectedHost: HostHeader('example.com', null),
+          ),
+          // IPv4 address tests
+          (
+            description:
+                'when a valid IPv4 address is passed then it should parse the host correctly',
+            hostValue: '192.168.1.1',
+            expectedHost: HostHeader('192.168.1.1', null),
+          ),
+          (
+            description:
+                'when a valid IPv4 address with port is passed then it should parse both host and port correctly',
+            hostValue: '192.168.1.1:8080',
+            expectedHost: HostHeader('192.168.1.1', 8080),
+          ),
+          (
+            description:
+                'when IPv4 loopback address is passed then it should parse correctly',
+            hostValue: '127.0.0.1',
+            expectedHost: HostHeader('127.0.0.1', null),
+          ),
+          (
+            description:
+                'when IPv4 loopback address with port is passed then it should parse both host and port correctly',
+            hostValue: '127.0.0.1:3000',
+            expectedHost: HostHeader('127.0.0.1', 3000),
+          ),
+          (
+            description:
+                'when IPv4 address with whitespace is passed then it should parse correctly',
+            hostValue: ' 10.0.0.1 ',
+            expectedHost: HostHeader('10.0.0.1', null),
+          ),
+          (
+            description:
+                'when IPv4 private network address is passed then it should parse correctly',
+            hostValue: '10.0.0.1:9000',
+            expectedHost: HostHeader('10.0.0.1', 9000),
+          ),
+          (
+            description:
+                'when IPv4 address with standard HTTP port is passed then it should parse correctly',
+            hostValue: '203.0.113.1:80',
+            expectedHost: HostHeader('203.0.113.1', 80),
+          ),
+          (
+            description:
+                'when IPv4 address with HTTPS port is passed then it should parse correctly',
+            hostValue: '203.0.113.1:443',
+            expectedHost: HostHeader('203.0.113.1', 443),
+          ),
+          (
+            description:
+                'when IPv4 address with high port number is passed then it should parse correctly',
+            hostValue: '172.16.0.1:65535',
+            expectedHost: HostHeader('172.16.0.1', 65535),
+          ),
+          (
+            description:
+                'when IPv4 broadcast address is passed then it should parse correctly',
+            hostValue: '255.255.255.255:8080',
+            expectedHost: HostHeader('255.255.255.255', 8080),
+          ),
+          (
+            description:
+                'when IPv4 zero address is passed then it should parse correctly',
+            hostValue: '0.0.0.0',
+            expectedHost: HostHeader('0.0.0.0', null),
+          ),
+          (
+            description:
+                'when IPv4 address with port 1 is passed then it should parse correctly',
+            hostValue: '192.168.0.1:1',
+            expectedHost: HostHeader('192.168.0.1', 1),
+          ),
+          (
+            description:
+                'when an IPv4-like address with high numbers is passed then it should parse as hostname correctly',
+            hostValue: '256.1.1.1',
+            expectedHost: HostHeader('256.1.1.1', null),
+          ),
+          (
+            description:
+                'when an IPv4-like address with extra octets is passed then it should parse as hostname correctly',
+            hostValue: '192.168.1.1.1',
+            expectedHost: HostHeader('192.168.1.1.1', null),
+          ),
+          (
+            description:
+                'when an IPv4-like address with negative numbers is passed then it should parse as hostname correctly',
+            hostValue: '192.168.-1.1:8080',
+            expectedHost: HostHeader('192.168.-1.1', 8080),
+          ),
+          // IPv6 address tests
+          (
+            description:
+                'when a valid IPv6 address in brackets is passed then it should parse the host correctly',
+            hostValue: '[2001:db8::1]',
+            expectedHost: HostHeader('[2001:db8::1]', null),
+          ),
+          (
+            description:
+                'when a valid IPv6 address in brackets with port is passed then it should parse both host and port correctly',
+            hostValue: '[2001:db8::1]:8080',
+            expectedHost: HostHeader('[2001:db8::1]', 8080),
+          ),
+          (
+            description:
+                'when an IPv6 loopback address in brackets is passed then it should parse correctly',
+            hostValue: '[::1]',
+            expectedHost: HostHeader('[::1]', null),
+          ),
+          (
+            description:
+                'when an IPv6 loopback address in brackets with port is passed then it should parse both host and port correctly',
+            hostValue: '[::1]:3000',
+            expectedHost: HostHeader('[::1]', 3000),
+          ),
+          (
+            description:
+                'when IPv6 address with whitespace is passed then it should parse correctly',
+            hostValue: ' [2001:db8::1] ',
+            expectedHost: HostHeader('[2001:db8::1]', null),
+          ),
+          (
+            description:
+                'when full IPv6 address in brackets is passed then it should parse correctly',
+            hostValue: '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
+            expectedHost:
+                HostHeader('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]', null),
+          ),
+          (
+            description:
+                'when IPv6 address with double colon compression is passed then it should parse correctly',
+            hostValue: '[2001:db8::8a2e:370:7334]:9000',
+            expectedHost: HostHeader('[2001:db8::8a2e:370:7334]', 9000),
+          ),
+          (
+            description:
+                'when IPv6 address ending with numbers that could be port is passed then it should parse correctly with brackets',
+            hostValue: '[2001:db8:85a3::8a2e:370:7334]:80',
+            expectedHost: HostHeader('[2001:db8:85a3::8a2e:370:7334]', 80),
+          ),
+          (
+            description:
+                'when IPv6 loopback with port-like ending is passed then it should parse correctly with brackets',
+            hostValue: '[::1]:8080',
+            expectedHost: HostHeader('[::1]', 8080),
+          ),
+          (
+            description:
+                'when IPv6 compressed notation that could be ambiguous is passed then it should parse correctly with brackets',
+            hostValue: '[::ffff:192.0.2.1]:443',
+            expectedHost: HostHeader('[::ffff:192.0.2.1]', 443),
+          ),
+          (
+            description:
+                'when IPv6 address with embedded IPv4 notation is passed then it should parse correctly with brackets',
+            hostValue: '[::ffff:192.168.1.1]',
+            expectedHost: HostHeader('[::ffff:192.168.1.1]', null),
+          ),
+          (
+            description:
+                'when IPv6 zero compression at end that could look like port is passed then it should parse correctly with brackets',
+            hostValue: '[2001:db8::]:3000',
+            expectedHost: HostHeader('[2001:db8::]', 3000),
+          ),
+          (
+            description:
+                'when IPv6 address ending exactly like common port 80 is passed then it should parse correctly with brackets',
+            hostValue: '[fe80::1:80]:8080',
+            expectedHost: HostHeader('[fe80::1:80]', 8080),
+          ),
+          (
+            description:
+                'when IPv6 address ending like port 443 is passed then it should parse correctly with brackets',
+            hostValue: '[2001:db8::443]:443',
+            expectedHost: HostHeader('[2001:db8::443]', 443),
+          ),
+          (
+            description:
+                'when minimal IPv6 with short notation is passed then it should parse correctly with brackets',
+            hostValue: '[::1:1]:1',
+            expectedHost: HostHeader('[::1:1]', 1),
+          ),
+          (
+            description:
+                'when IPv6 with multiple consecutive numbers is passed then it should parse correctly with brackets',
+            hostValue: '[2001:0:0:0:0:0:0:8080]',
+            expectedHost: HostHeader('[2001:0:0:0:0:0:0:8080]', null),
+          ),
+          (
+            description:
+                'when IPv6 with embedded IPv4 ending in port-like numbers is passed then it should parse correctly with brackets',
+            hostValue: '[64:ff9b::192.0.2.80]:80',
+            expectedHost: HostHeader('[64:ff9b::192.0.2.80]', 80),
+          ),
           // Note: Unbracketed IPv6 addresses like '::1' cannot be tested here
           // because they cause URL parsing failures at the HTTP client level
-          // before reaching the header validation logic. This demonstrates
-          // why RFC 3986 requires brackets for all IPv6 addresses in URIs.
-        });
-      });
+          // before reaching the header validation logic.
+        ],
+        (final testCase) => testCase.description,
+        (final testCase) async {
+          final headers = await getServerRequestHeaders(
+            server: server,
+            headers: {'host': testCase.hostValue},
+            touchHeaders: (final h) => h.host,
+          );
+
+          expect(headers.host, equals(testCase.expectedHost));
+        },
+      );
     },
   );
-
-  group('Given a Host header with the strict flag false', () {
-    late RelicServer server;
-
-    setUp(() async {
-      server = await createServer(strictHeaders: false);
-    });
-
-    tearDown(() => server.close());
-
-    group('when an invalid Host header is passed', () {
-      test(
-        'then it should return null',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            touchHeaders: (final _) {},
-            headers: {'host': 'h@ttp://example.com'},
-          );
-
-          expect(Headers.host[headers].valueOrNullIfInvalid, isNull);
-          expect(() => headers.host, throwsInvalidHeader);
-        },
-      );
-    });
-
-    test(
-      'when no Host header is passed then it should default to machine address',
-      () async {
-        final headers = await getServerRequestHeaders(
-          server: server,
-          headers: {},
-          touchHeaders: (final h) => h.host,
-        );
-
-        expect(headers.host, isNotNull);
-      },
-    );
-
-    group('when IPv6 Host headers are passed', () {
-      test(
-        'when a valid IPv6 address in brackets is passed '
-        'then it should parse correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': '[2001:db8::1]'},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host, equals(HostHeader('[2001:db8::1]', null)));
-        },
-      );
-
-      test(
-        'when a valid IPv6 address in brackets with port is passed '
-        'then it should parse both host and port correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': '[::1]:3000'},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host?.port, equals(3000));
-        },
-      );
-
-      test(
-        'when IPv6 address with whitespace is passed '
-        'then it should parse correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': ' [::1]:8080 '},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host?.port, equals(8080));
-        },
-      );
-
-      test(
-        'when full IPv6 address in brackets with port is passed '
-        'then it should parse correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443'},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host?.port, equals(443));
-        },
-      );
-
-      test(
-        'when IPv6 address with double colon compression is passed '
-        'then it should parse correctly',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            headers: {'host': '[2001:db8::8a2e:370:7334]'},
-            touchHeaders: (final h) => h.host,
-          );
-
-          expect(headers.host,
-              equals(HostHeader('[2001:db8::8a2e:370:7334]', null)));
-        },
-      );
-
-      group('when ambiguous IPv6 addresses are used', () {
-        test(
-          'when IPv6 address ending with numbers that could be port is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[2001:db8:85a3::8a2e:370:7334]:80'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(80));
-          },
-        );
-
-        test(
-          'when IPv6 loopback with port-like ending is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[::1]:8080'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(8080));
-          },
-        );
-
-        test(
-          'when IPv6 compressed notation that could be ambiguous is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[::ffff:192.0.2.1]:443'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(443));
-          },
-        );
-
-        test(
-          'when IPv6 address with embedded IPv4 notation is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[::ffff:192.168.1.1]'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(
-                headers.host, equals(HostHeader('[::ffff:192.168.1.1]', null)));
-          },
-        );
-
-        test(
-          'when IPv6 zero compression at end that could look like port is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[2001:db8::]:3000'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(3000));
-          },
-        );
-      });
-
-      group('when extremely ambiguous IPv6 addresses are used', () {
-        test(
-          'when IPv6 address ending exactly like common port 80 is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[fe80::1:80]:8080'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(8080));
-          },
-        );
-
-        test(
-          'when IPv6 address ending like port 443 is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[2001:db8::443]:443'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(443));
-          },
-        );
-
-        test(
-          'when minimal IPv6 with short notation is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[::1:1]:1'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(1));
-          },
-        );
-
-        test(
-          'when IPv6 with multiple consecutive numbers is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[2001:0:0:0:0:0:0:8080]'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host,
-                equals(HostHeader('[2001:0:0:0:0:0:0:8080]', null)));
-          },
-        );
-
-        test(
-          'when IPv6 with embedded IPv4 ending in port-like numbers is passed '
-          'then it should parse correctly with brackets',
-          () async {
-            final headers = await getServerRequestHeaders(
-              server: server,
-              headers: {'host': '[64:ff9b::192.0.2.80]:80'},
-              touchHeaders: (final h) => h.host,
-            );
-
-            expect(headers.host?.port, equals(80));
-          },
-        );
-
-        // Note: Unbracketed IPv6 addresses like '::1' cannot be tested here
-        // because they cause URL parsing failures at the HTTP client level
-        // before reaching the header validation logic. This demonstrates
-        // why RFC 3986 requires brackets for all IPv6 addresses in URIs.
-      });
-    });
-  });
 }

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -687,7 +687,7 @@ void main() {
         Headers.from,
         (final h) => h.from = FromHeader(emails: ['info@serverpod.com'])
       ),
-      (Headers.host, (final h) => h.host = Uri.parse('www.example.com:80')),
+      (Headers.host, (final h) => h.host = HostHeader('www.example.com', 80)),
       (
         Headers.ifMatch,
         (final h) => h.ifMatch = const IfMatchHeader.wildcard()

--- a/test/headers/headers_test_utils.dart
+++ b/test/headers/headers_test_utils.dart
@@ -54,7 +54,7 @@ extension RelicServerTestEx on RelicServer {
 }
 
 /// Creates a [RelicServer] that listens on the loopback IPv4 address.
-Future<RelicServer> createServer({required final bool strictHeaders}) async {
+Future<RelicServer> createServer({final bool strictHeaders = false}) async {
   final adapter = IOAdapter(await bindHttpServer(InternetAddress.loopbackIPv4));
   return RelicServer(adapter, strictHeaders: strictHeaders);
 }


### PR DESCRIPTION
## Description
Don't treat 'Host' header as a `Uri`. Fx, it cannot contain a scheme (http(s)). Format is defined in RFC3986.
 
## Related Issues
- Fixes: #95 

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [x] Includes breaking changes.
- [ ] No breaking changes.

`host` extension on `Headers` is now of type `HostHeader`. Used to be `Uri`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a typed HostHeader for the HTTP Host header with host and optional port, including value-based equality and parsing/encoding.
  - Updates headers.host getter/setter to use HostHeader instead of Uri.
  - Expands typed header exports to include HostHeader and X-Forwarded-For.
- Tests
  - Updated tests to validate HostHeader behavior (whitespace handling, ports, basic IPv6), replacing Uri-based expectations and messages where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->