### PR TITLE
feat: Add operator== and hashCode on all header classes

### DIFF
--- a/lib/src/headers/codecs/common_types_codecs.dart
+++ b/lib/src/headers/codecs/common_types_codecs.dart
@@ -162,6 +162,6 @@ List<RequestMethod> parseMethodList(final Iterable<String> values) {
 
 /// Encode a list of methods to a iterable of string.
 Iterable<String> encodeMethodList(final List<RequestMethod> l) =>
-    l.map((final r) => '$r');
+    l.expand((final r) => RequestMethod.codec.encode(r));
 
 const methodListCodec = HeaderCodec(parseMethodList, encodeMethodList);

--- a/lib/src/headers/headers.dart
+++ b/lib/src/headers/headers.dart
@@ -4,7 +4,6 @@ import 'package:http_parser/http_parser.dart';
 
 import '../../relic.dart';
 import 'codecs/common_types_codecs.dart';
-import 'typed/headers/x_forwarded_for_header.dart';
 
 part 'mutable_headers.dart';
 

--- a/lib/src/headers/standard_headers_extensions.dart
+++ b/lib/src/headers/standard_headers_extensions.dart
@@ -1,6 +1,5 @@
 import '../method/request_method.dart';
 import 'headers.dart';
-import 'typed/headers/x_forwarded_for_header.dart';
 import 'typed/typed_headers.dart';
 
 extension HeadersEx on Headers {

--- a/lib/src/headers/typed/headers/accept_encoding_header.dart
+++ b/lib/src/headers/typed/headers/accept_encoding_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -68,6 +70,18 @@ final class AcceptEncodingHeader {
       : encodings?.map((final e) => e._encode()).join(', ') ?? '';
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AcceptEncodingHeader &&
+          isWildcard == other.isWildcard &&
+          const ListEquality<EncodingQuality>()
+              .equals(encodings, other.encodings);
+
+  @override
+  int get hashCode => Object.hash(
+      isWildcard, const ListEquality<EncodingQuality>().hash(encodings));
+
+  @override
   String toString() => 'AcceptEncodingHeader(encodings: $encodings)';
 }
 
@@ -85,6 +99,16 @@ class EncodingQuality {
 
   /// Converts the [EncodingQuality] instance into a string representation suitable for HTTP headers.
   String _encode() => quality == 1.0 ? encoding : '$encoding;q=$quality';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is EncodingQuality &&
+          encoding == other.encoding &&
+          quality == other.quality;
+
+  @override
+  int get hashCode => Object.hash(encoding, quality);
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/accept_encoding_header.dart
+++ b/lib/src/headers/typed/headers/accept_encoding_header.dart
@@ -12,18 +12,19 @@ final class AcceptEncodingHeader {
       [value._encode()];
 
   /// The list of encodings that are accepted.
-  final List<EncodingQuality>? encodings;
+  final List<EncodingQuality> encodings;
 
   /// A boolean value indicating whether the Accept-Encoding header is a wildcard.
   final bool isWildcard;
 
   /// Constructs an instance of [AcceptEncodingHeader] with the given encodings.
   AcceptEncodingHeader.encodings({required this.encodings})
-      : isWildcard = false;
+      : assert(encodings.isNotEmpty),
+        isWildcard = false;
 
   /// Constructs an instance of [AcceptEncodingHeader] with a wildcard encoding.
-  AcceptEncodingHeader.wildcard()
-      : encodings = null,
+  const AcceptEncodingHeader.wildcard()
+      : encodings = const [],
         isWildcard = true;
 
   /// Parses the Accept-Encoding header value and returns an [AcceptEncodingHeader] instance.
@@ -35,7 +36,7 @@ final class AcceptEncodingHeader {
     }
 
     if (splitValues.length == 1 && splitValues.first == '*') {
-      return AcceptEncodingHeader.wildcard();
+      return const AcceptEncodingHeader.wildcard();
     }
 
     if (splitValues.length > 1 && splitValues.contains('*')) {
@@ -65,9 +66,8 @@ final class AcceptEncodingHeader {
 
   /// Converts the [AcceptEncodingHeader] instance into a string representation suitable for HTTP headers.
 
-  String _encode() => isWildcard
-      ? '*'
-      : encodings?.map((final e) => e._encode()).join(', ') ?? '';
+  String _encode() =>
+      isWildcard ? '*' : encodings.map((final e) => e._encode()).join(', ');
 
   @override
   bool operator ==(final Object other) =>

--- a/lib/src/headers/typed/headers/accept_encoding_header.dart
+++ b/lib/src/headers/typed/headers/accept_encoding_header.dart
@@ -18,8 +18,10 @@ final class AcceptEncodingHeader {
   final bool isWildcard;
 
   /// Constructs an instance of [AcceptEncodingHeader] with the given encodings.
-  AcceptEncodingHeader.encodings({required this.encodings})
+  AcceptEncodingHeader.encodings(
+      {required final List<EncodingQuality> encodings})
       : assert(encodings.isNotEmpty),
+        encodings = List.unmodifiable(encodings),
         isWildcard = false;
 
   /// Constructs an instance of [AcceptEncodingHeader] with a wildcard encoding.

--- a/lib/src/headers/typed/headers/accept_header.dart
+++ b/lib/src/headers/typed/headers/accept_header.dart
@@ -14,7 +14,9 @@ final class AcceptHeader {
   final List<MediaRange> mediaRanges;
 
   /// Constructs an [AcceptHeader] instance with the specified media ranges.
-  const AcceptHeader({required this.mediaRanges});
+  AcceptHeader({required final List<MediaRange> mediaRanges})
+      : assert(mediaRanges.isNotEmpty),
+        mediaRanges = List.unmodifiable(mediaRanges);
 
   /// Parses the Accept header value and returns an [AcceptHeader] instance.
   ///

--- a/lib/src/headers/typed/headers/accept_header.dart
+++ b/lib/src/headers/typed/headers/accept_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -31,6 +33,16 @@ final class AcceptHeader {
 
   /// Converts the [AcceptHeader] instance into a string representation suitable for HTTP headers.
   String _encode() => mediaRanges.map((final mr) => mr._encode()).join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AcceptHeader &&
+          const ListEquality<MediaRange>()
+              .equals(mediaRanges, other.mediaRanges);
+
+  @override
+  int get hashCode => const ListEquality<MediaRange>().hash(mediaRanges);
 
   @override
   String toString() => 'AcceptHeader(mediaRanges: $mediaRanges)';
@@ -91,6 +103,17 @@ class MediaRange {
     final qualityStr = quality == 1.0 ? '' : ';q=$quality';
     return '$type/$subtype$qualityStr';
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is MediaRange &&
+          type == other.type &&
+          subtype == other.subtype &&
+          quality == other.quality;
+
+  @override
+  int get hashCode => Object.hash(type, subtype, quality);
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/accept_language_header.dart
+++ b/lib/src/headers/typed/headers/accept_language_header.dart
@@ -18,8 +18,10 @@ final class AcceptLanguageHeader {
   final bool isWildcard;
 
   /// Constructs an instance of [AcceptLanguageHeader] with the given languages.
-  AcceptLanguageHeader.languages({required this.languages})
+  AcceptLanguageHeader.languages(
+      {required final List<LanguageQuality> languages})
       : assert(languages.isNotEmpty),
+        languages = List.unmodifiable(languages),
         isWildcard = false;
 
   /// Constructs an instance of [AcceptLanguageHeader] with a wildcard language.

--- a/lib/src/headers/typed/headers/accept_language_header.dart
+++ b/lib/src/headers/typed/headers/accept_language_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -67,6 +69,18 @@ final class AcceptLanguageHeader {
       : languages?.map((final e) => e._encode()).join(', ') ?? '';
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AcceptLanguageHeader &&
+          isWildcard == other.isWildcard &&
+          const ListEquality<LanguageQuality>()
+              .equals(languages, other.languages);
+
+  @override
+  int get hashCode => Object.hash(
+      isWildcard, const ListEquality<LanguageQuality>().hash(languages));
+
+  @override
   String toString() => 'AcceptLanguageHeader(languages: $languages)';
 }
 
@@ -84,6 +98,16 @@ class LanguageQuality {
 
   /// Converts the [LanguageQuality] instance into a string representation suitable for HTTP headers.
   String _encode() => quality == 1.0 ? language : '$language;q=$quality';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is LanguageQuality &&
+          language == other.language &&
+          quality == other.quality;
+
+  @override
+  int get hashCode => Object.hash(language, quality);
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/accept_language_header.dart
+++ b/lib/src/headers/typed/headers/accept_language_header.dart
@@ -12,18 +12,19 @@ final class AcceptLanguageHeader {
       [value._encode()];
 
   /// The list of languages that are accepted.
-  final List<LanguageQuality>? languages;
+  final List<LanguageQuality> languages;
 
   /// A boolean value indicating whether the Accept-Language header is a wildcard.
   final bool isWildcard;
 
   /// Constructs an instance of [AcceptLanguageHeader] with the given languages.
-  const AcceptLanguageHeader.languages({required this.languages})
-      : isWildcard = false;
+  AcceptLanguageHeader.languages({required this.languages})
+      : assert(languages.isNotEmpty),
+        isWildcard = false;
 
   /// Constructs an instance of [AcceptLanguageHeader] with a wildcard language.
   const AcceptLanguageHeader.wildcard()
-      : languages = null,
+      : languages = const [],
         isWildcard = true;
 
   /// Parses the Accept-Language header value and returns an [AcceptLanguageHeader] instance.
@@ -64,9 +65,8 @@ final class AcceptLanguageHeader {
   }
 
   /// Converts the [AcceptLanguageHeader] instance into a string representation suitable for HTTP headers.
-  String _encode() => isWildcard
-      ? '*'
-      : languages?.map((final e) => e._encode()).join(', ') ?? '';
+  String _encode() =>
+      isWildcard ? '*' : languages.map((final e) => e._encode()).join(', ');
 
   @override
   bool operator ==(final Object other) =>
@@ -93,7 +93,7 @@ class LanguageQuality {
   final double? quality;
 
   /// Constructs an instance of [LanguageQuality].
-  LanguageQuality(this.language, [final double? quality])
+  const LanguageQuality(this.language, [final double? quality])
       : quality = quality ?? 1.0;
 
   /// Converts the [LanguageQuality] instance into a string representation suitable for HTTP headers.

--- a/lib/src/headers/typed/headers/accept_ranges_header.dart
+++ b/lib/src/headers/typed/headers/accept_ranges_header.dart
@@ -43,6 +43,15 @@ final class AcceptRangesHeader {
   /// Converts the [AcceptRangesHeader] instance into a string representation suitable for HTTP headers.
 
   String _encode() => rangeUnit ?? 'none';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AcceptRangesHeader && rangeUnit == other.rangeUnit;
+
+  @override
+  int get hashCode => rangeUnit.hashCode;
+
   @override
   String toString() {
     return 'AcceptRangesHeader(rangeUnit: $rangeUnit)';

--- a/lib/src/headers/typed/headers/accept_ranges_header.dart
+++ b/lib/src/headers/typed/headers/accept_ranges_header.dart
@@ -8,19 +8,19 @@ final class AcceptRangesHeader {
   static List<String> __encode(final AcceptRangesHeader value) =>
       [value._encode()];
 
-  /// The range unit supported by the server, or `null` if no specific unit is supported.
-  final String? rangeUnit;
+  /// The range unit supported by the server, or `none` if not supported.
+  final String rangeUnit;
 
   /// Constructs an [AcceptRangesHeader] instance with the specified range unit.
-  const AcceptRangesHeader({this.rangeUnit});
+  const AcceptRangesHeader._({required this.rangeUnit});
 
   /// Constructs an [AcceptRangesHeader] instance with the range unit set to 'none'.
   factory AcceptRangesHeader.none() =>
-      const AcceptRangesHeader(rangeUnit: 'none');
+      const AcceptRangesHeader._(rangeUnit: 'none');
 
   /// Constructs an [AcceptRangesHeader] instance with the range unit set to 'bytes'.
   factory AcceptRangesHeader.bytes() =>
-      const AcceptRangesHeader(rangeUnit: 'bytes');
+      const AcceptRangesHeader._(rangeUnit: 'bytes');
 
   /// Parses the Accept-Ranges header value and returns an [AcceptRangesHeader] instance.
   ///
@@ -31,18 +31,18 @@ final class AcceptRangesHeader {
       throw const FormatException('Value cannot be empty');
     }
 
-    return AcceptRangesHeader(rangeUnit: trimmed);
+    return AcceptRangesHeader._(rangeUnit: trimmed);
   }
 
   /// Returns `true` if the range unit is 'bytes', otherwise `false`.
   bool get isBytes => rangeUnit == 'bytes';
 
   /// Returns `true` if the range unit is 'none' or `null`, otherwise `false`.
-  bool get isNone => rangeUnit == 'none' || rangeUnit == null;
+  bool get isNone => rangeUnit == 'none';
 
   /// Converts the [AcceptRangesHeader] instance into a string representation suitable for HTTP headers.
 
-  String _encode() => rangeUnit ?? 'none';
+  String _encode() => rangeUnit;
 
   @override
   bool operator ==(final Object other) =>

--- a/lib/src/headers/typed/headers/access_control_allow_headers_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_headers_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -52,6 +54,17 @@ final class AccessControlAllowHeadersHeader {
   /// representation suitable for HTTP headers.
 
   String _encode() => isWildcard ? '*' : headers!.join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AccessControlAllowHeadersHeader &&
+          isWildcard == other.isWildcard &&
+          const IterableEquality<String>().equals(headers, other.headers);
+
+  @override
+  int get hashCode =>
+      Object.hash(isWildcard, const IterableEquality<String>().hash(headers));
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/access_control_allow_headers_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_headers_header.dart
@@ -14,14 +14,16 @@ final class AccessControlAllowHeadersHeader {
       [value._encode()];
 
   /// The list of headers that are allowed.
-  final Iterable<String> headers;
+  final List<String> headers;
 
   /// Whether all headers are allowed (`*`).
   final bool isWildcard;
 
   /// Constructs an instance allowing specific headers to be allowed.
-  AccessControlAllowHeadersHeader.headers({required this.headers})
+  AccessControlAllowHeadersHeader.headers(
+      {required final Iterable<String> headers})
       : assert(headers.isNotEmpty),
+        headers = List.unmodifiable(headers),
         isWildcard = false;
 
   /// Constructs an instance allowing all headers to be allowed (`*`).
@@ -61,11 +63,11 @@ final class AccessControlAllowHeadersHeader {
       identical(this, other) ||
       other is AccessControlAllowHeadersHeader &&
           isWildcard == other.isWildcard &&
-          const IterableEquality<String>().equals(headers, other.headers);
+          const ListEquality<String>().equals(headers, other.headers);
 
   @override
   int get hashCode =>
-      Object.hash(isWildcard, const IterableEquality<String>().hash(headers));
+      Object.hash(isWildcard, const ListEquality<String>().hash(headers));
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/access_control_allow_headers_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_headers_header.dart
@@ -14,18 +14,19 @@ final class AccessControlAllowHeadersHeader {
       [value._encode()];
 
   /// The list of headers that are allowed.
-  final Iterable<String>? headers;
+  final Iterable<String> headers;
 
   /// Whether all headers are allowed (`*`).
   final bool isWildcard;
 
   /// Constructs an instance allowing specific headers to be allowed.
-  const AccessControlAllowHeadersHeader.headers({required this.headers})
-      : isWildcard = false;
+  AccessControlAllowHeadersHeader.headers({required this.headers})
+      : assert(headers.isNotEmpty),
+        isWildcard = false;
 
   /// Constructs an instance allowing all headers to be allowed (`*`).
   const AccessControlAllowHeadersHeader.wildcard()
-      : headers = null,
+      : headers = const [],
         isWildcard = true;
 
   /// Parses the Access-Control-Allow-Headers header value and returns an
@@ -53,7 +54,7 @@ final class AccessControlAllowHeadersHeader {
   /// Converts the [AccessControlAllowHeadersHeader] instance into a string
   /// representation suitable for HTTP headers.
 
-  String _encode() => isWildcard ? '*' : headers!.join(', ');
+  String _encode() => isWildcard ? '*' : headers.join(', ');
 
   @override
   bool operator ==(final Object other) =>

--- a/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
@@ -57,7 +57,8 @@ final class AccessControlAllowMethodsHeader {
   /// Converts the [AccessControlAllowMethodsHeader] instance into a string
   /// representation suitable for HTTP headers.
 
-  String _encode() => isWildcard ? '*' : methods.join(', ');
+  String _encode() =>
+      isWildcard ? '*' : methods.map((final m) => m.name).join(', ');
 
   @override
   bool operator ==(final Object other) =>

--- a/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
@@ -20,8 +20,10 @@ final class AccessControlAllowMethodsHeader {
   final bool isWildcard;
 
   /// Constructs an instance allowing specific methods to be allowed.
-  AccessControlAllowMethodsHeader.methods({required this.methods})
+  AccessControlAllowMethodsHeader.methods(
+      {required final List<RequestMethod> methods})
       : assert(methods.isNotEmpty),
+        methods = List.unmodifiable(methods),
         isWildcard = false;
 
   /// Constructs an instance allowing all methods to be allowed (`*`).

--- a/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -55,6 +57,17 @@ final class AccessControlAllowMethodsHeader {
   /// representation suitable for HTTP headers.
 
   String _encode() => isWildcard ? '*' : methods!.join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AccessControlAllowMethodsHeader &&
+          isWildcard == other.isWildcard &&
+          const ListEquality<RequestMethod>().equals(methods, other.methods);
+
+  @override
+  int get hashCode => Object.hash(
+      isWildcard, const ListEquality<RequestMethod>().hash(methods));
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
@@ -14,18 +14,19 @@ final class AccessControlAllowMethodsHeader {
       [value._encode()];
 
   /// The list of methods that are allowed.
-  final List<RequestMethod>? methods;
+  final List<RequestMethod> methods;
 
   /// Whether all methods are allowed (`*`).
   final bool isWildcard;
 
   /// Constructs an instance allowing specific methods to be allowed.
-  const AccessControlAllowMethodsHeader.methods({required this.methods})
-      : isWildcard = false;
+  AccessControlAllowMethodsHeader.methods({required this.methods})
+      : assert(methods.isNotEmpty),
+        isWildcard = false;
 
   /// Constructs an instance allowing all methods to be allowed (`*`).
   const AccessControlAllowMethodsHeader.wildcard()
-      : methods = null,
+      : methods = const [],
         isWildcard = true;
 
   /// Parses the Access-Control-Allow-Methods header value and returns an
@@ -56,7 +57,7 @@ final class AccessControlAllowMethodsHeader {
   /// Converts the [AccessControlAllowMethodsHeader] instance into a string
   /// representation suitable for HTTP headers.
 
-  String _encode() => isWildcard ? '*' : methods!.join(', ');
+  String _encode() => isWildcard ? '*' : methods.join(', ');
 
   @override
   bool operator ==(final Object other) =>

--- a/lib/src/headers/typed/headers/access_control_allow_origin_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_origin_header.dart
@@ -54,6 +54,16 @@ final class AccessControlAllowOriginHeader {
   String _encode() => isWildcard ? '*' : origin.toString();
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AccessControlAllowOriginHeader &&
+          isWildcard == other.isWildcard &&
+          origin == other.origin;
+
+  @override
+  int get hashCode => Object.hash(isWildcard, origin);
+
+  @override
   String toString() =>
       'AccessControlAllowOriginHeader(origin: $origin, isWildcard: $isWildcard)';
 }

--- a/lib/src/headers/typed/headers/access_control_expose_headers_header.dart
+++ b/lib/src/headers/typed/headers/access_control_expose_headers_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -12,18 +14,19 @@ final class AccessControlExposeHeadersHeader {
       [value._encode()];
 
   /// The list of headers that can be exposed.
-  final Iterable<String>? headers;
+  final Iterable<String> headers;
 
   /// Whether all headers are allowed to be exposed (`*`).
   final bool isWildcard;
 
   /// Constructs an instance allowing specific headers to be exposed.
-  const AccessControlExposeHeadersHeader.headers({required this.headers})
-      : isWildcard = false;
+  AccessControlExposeHeadersHeader.headers({required this.headers})
+      : assert(headers.isNotEmpty),
+        isWildcard = false;
 
   /// Constructs an instance allowing all headers to be exposed (`*`).
   const AccessControlExposeHeadersHeader.wildcard()
-      : headers = null,
+      : headers = const [],
         isWildcard = true;
 
   /// Parses the Access-Control-Expose-Headers header value and returns an
@@ -52,7 +55,18 @@ final class AccessControlExposeHeadersHeader {
   /// Converts the [AccessControlExposeHeadersHeader] instance into a string
   /// representation suitable for HTTP headers.
 
-  String _encode() => isWildcard ? '*' : headers?.join(', ') ?? '';
+  String _encode() => isWildcard ? '*' : headers.join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AccessControlExposeHeadersHeader &&
+          isWildcard == other.isWildcard &&
+          const IterableEquality<String>().equals(headers, other.headers);
+
+  @override
+  int get hashCode =>
+      Object.hash(isWildcard, const IterableEquality<String>().hash(headers));
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/access_control_expose_headers_header.dart
+++ b/lib/src/headers/typed/headers/access_control_expose_headers_header.dart
@@ -14,14 +14,16 @@ final class AccessControlExposeHeadersHeader {
       [value._encode()];
 
   /// The list of headers that can be exposed.
-  final Iterable<String> headers;
+  final List<String> headers;
 
   /// Whether all headers are allowed to be exposed (`*`).
   final bool isWildcard;
 
   /// Constructs an instance allowing specific headers to be exposed.
-  AccessControlExposeHeadersHeader.headers({required this.headers})
+  AccessControlExposeHeadersHeader.headers(
+      {required final Iterable<String> headers})
       : assert(headers.isNotEmpty),
+        headers = List.unmodifiable(headers),
         isWildcard = false;
 
   /// Constructs an instance allowing all headers to be exposed (`*`).
@@ -62,11 +64,11 @@ final class AccessControlExposeHeadersHeader {
       identical(this, other) ||
       other is AccessControlExposeHeadersHeader &&
           isWildcard == other.isWildcard &&
-          const IterableEquality<String>().equals(headers, other.headers);
+          const ListEquality<String>().equals(headers, other.headers);
 
   @override
   int get hashCode =>
-      Object.hash(isWildcard, const IterableEquality<String>().hash(headers));
+      Object.hash(isWildcard, const ListEquality<String>().hash(headers));
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/authentication_header.dart
+++ b/lib/src/headers/typed/headers/authentication_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 
 /// A class representing the HTTP Authentication header.
@@ -67,6 +69,18 @@ final class AuthenticationHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AuthenticationHeader &&
+          scheme == other.scheme &&
+          const ListEquality<AuthenticationParameter>()
+              .equals(parameters, other.parameters);
+
+  @override
+  int get hashCode => Object.hash(
+      scheme, const ListEquality<AuthenticationParameter>().hash(parameters));
+
+  @override
   String toString() {
     return 'AuthenticationHeader(scheme: $scheme, parameters: $parameters)';
   }
@@ -78,6 +92,16 @@ class AuthenticationParameter {
   final String value;
 
   const AuthenticationParameter(this.key, this.value);
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AuthenticationParameter &&
+          key == other.key &&
+          value == other.value;
+
+  @override
+  int get hashCode => Object.hash(key, value);
 
   @override
   String toString() => 'AuthenticationParameter(key: $key, value: $value)';

--- a/lib/src/headers/typed/headers/authentication_header.dart
+++ b/lib/src/headers/typed/headers/authentication_header.dart
@@ -14,11 +14,16 @@ final class AuthenticationHeader {
   /// The parameters associated with the authentication scheme.
   final List<AuthenticationParameter> parameters;
 
-  /// Constructs an [AuthenticationHeader] instance with the specified scheme and parameters.
-  const AuthenticationHeader({
+  const AuthenticationHeader._({
     required this.scheme,
     required this.parameters,
   });
+
+  /// Constructs an [AuthenticationHeader] instance with the specified scheme and parameters.
+  AuthenticationHeader({
+    required this.scheme,
+    required final List<AuthenticationParameter> parameters,
+  }) : parameters = List.unmodifiable(parameters);
 
   /// Parses the Authentication header value and returns an [AuthenticationHeader] instance.
   factory AuthenticationHeader.parse(final String value) {
@@ -55,7 +60,7 @@ final class AuthenticationHeader {
       }
     }
 
-    return AuthenticationHeader(scheme: scheme, parameters: parameters);
+    return AuthenticationHeader._(scheme: scheme, parameters: parameters);
   }
 
   /// Converts the [AuthenticationHeader] instance into a string representation

--- a/lib/src/headers/typed/headers/authorization_header.dart
+++ b/lib/src/headers/typed/headers/authorization_header.dart
@@ -44,6 +44,14 @@ abstract class AuthorizationHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is AuthorizationHeader && headerValue == other.headerValue;
+
+  @override
+  int get hashCode => headerValue.hashCode;
+
+  @override
   String toString() => 'AuthorizationHeader(headerValue: $headerValue)';
 }
 
@@ -95,6 +103,14 @@ final class BearerAuthorizationHeader extends AuthorizationHeader {
   /// Returns the full authorization string, including the "Bearer " prefix.
   @override
   String get headerValue => '$prefix$token';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is BearerAuthorizationHeader && token == other.token;
+
+  @override
+  int get hashCode => token.hashCode;
 
   @override
   String toString() => 'BearerAuthorizationHeader(token: $token)';
@@ -166,6 +182,16 @@ final class BasicAuthorizationHeader extends AuthorizationHeader {
     final credentials = base64Encode(utf8.encode('$username:$password'));
     return '$prefix$credentials';
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is BasicAuthorizationHeader &&
+          username == other.username &&
+          password == other.password;
+
+  @override
+  int get hashCode => Object.hash(username, password);
 
   @override
   String toString() =>
@@ -325,6 +351,35 @@ final class DigestAuthorizationHeader extends AuthorizationHeader {
       if (opaque != null) '$_opaque="$opaque"'
     ].join(', ');
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is DigestAuthorizationHeader &&
+          username == other.username &&
+          realm == other.realm &&
+          nonce == other.nonce &&
+          uri == other.uri &&
+          response == other.response &&
+          algorithm == other.algorithm &&
+          qop == other.qop &&
+          nc == other.nc &&
+          cnonce == other.cnonce &&
+          opaque == other.opaque;
+
+  @override
+  int get hashCode => Object.hashAll([
+        username,
+        realm,
+        nonce,
+        uri,
+        response,
+        algorithm,
+        qop,
+        nc,
+        cnonce,
+        opaque,
+      ]);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/authorization_header.dart
+++ b/lib/src/headers/typed/headers/authorization_header.dart
@@ -42,17 +42,6 @@ abstract class AuthorizationHeader {
 
     throw const FormatException('Invalid header format');
   }
-
-  @override
-  bool operator ==(final Object other) =>
-      identical(this, other) ||
-      other is AuthorizationHeader && headerValue == other.headerValue;
-
-  @override
-  int get hashCode => headerValue.hashCode;
-
-  @override
-  String toString() => 'AuthorizationHeader(headerValue: $headerValue)';
 }
 
 /// Represents a Bearer token for HTTP Authorization.

--- a/lib/src/headers/typed/headers/cache_control_header.dart
+++ b/lib/src/headers/typed/headers/cache_control_header.dart
@@ -251,6 +251,47 @@ final class CacheControlHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is CacheControlHeader &&
+          noCache == other.noCache &&
+          noStore == other.noStore &&
+          maxAge == other.maxAge &&
+          staleWhileRevalidate == other.staleWhileRevalidate &&
+          publicCache == other.publicCache &&
+          privateCache == other.privateCache &&
+          mustRevalidate == other.mustRevalidate &&
+          proxyRevalidate == other.proxyRevalidate &&
+          sMaxAge == other.sMaxAge &&
+          noTransform == other.noTransform &&
+          onlyIfCached == other.onlyIfCached &&
+          staleIfError == other.staleIfError &&
+          maxStale == other.maxStale &&
+          minFresh == other.minFresh &&
+          immutable == other.immutable &&
+          mustUnderstand == other.mustUnderstand;
+
+  @override
+  int get hashCode => Object.hashAll([
+        noCache,
+        noStore,
+        maxAge,
+        staleWhileRevalidate,
+        publicCache,
+        privateCache,
+        mustRevalidate,
+        proxyRevalidate,
+        sMaxAge,
+        noTransform,
+        onlyIfCached,
+        staleIfError,
+        maxStale,
+        minFresh,
+        immutable,
+        mustUnderstand,
+      ]);
+
+  @override
   String toString() {
     return 'CacheControlHeader('
         'noCache: $noCache, '

--- a/lib/src/headers/typed/headers/clear_site_data_header.dart
+++ b/lib/src/headers/typed/headers/clear_site_data_header.dart
@@ -12,18 +12,21 @@ final class ClearSiteDataHeader {
       [value._encode()];
 
   /// The list of data types to be cleared.
-  final List<ClearSiteDataType>? dataTypes;
+  final List<ClearSiteDataType> dataTypes;
 
   /// Whether all data types are allowed to be cleared (`*`).
   final bool isWildcard;
 
   /// Constructs an instance allowing specific data types to be cleared.
-  const ClearSiteDataHeader.dataTypes({required this.dataTypes})
-      : isWildcard = false;
+  ClearSiteDataHeader.dataTypes(
+      {required final List<ClearSiteDataType> dataTypes})
+      : assert(dataTypes.isNotEmpty),
+        dataTypes = List.unmodifiable(dataTypes),
+        isWildcard = false;
 
   /// Constructs an instance allowing all data types to be cleared (`*`).
   const ClearSiteDataHeader.wildcard()
-      : dataTypes = null,
+      : dataTypes = const [],
         isWildcard = true;
 
   /// Parses the Clear-Site-Data header value and returns a [ClearSiteDataHeader] instance.
@@ -61,7 +64,7 @@ final class ClearSiteDataHeader {
   String _encode() {
     return isWildcard
         ? '*'
-        : dataTypes!.map((final dataType) => '"${dataType.value}"').join(', ');
+        : dataTypes.map((final dataType) => '"${dataType.value}"').join(', ');
   }
 
   @override

--- a/lib/src/headers/typed/headers/clear_site_data_header.dart
+++ b/lib/src/headers/typed/headers/clear_site_data_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -63,6 +65,18 @@ final class ClearSiteDataHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ClearSiteDataHeader &&
+          isWildcard == other.isWildcard &&
+          const ListEquality<ClearSiteDataType>()
+              .equals(dataTypes, other.dataTypes);
+
+  @override
+  int get hashCode => Object.hash(
+      isWildcard, const ListEquality<ClearSiteDataType>().hash(dataTypes));
+
+  @override
   String toString() =>
       'ClearSiteDataHeader(dataTypes: $dataTypes, isWildcard: $isWildcard)';
 }
@@ -106,6 +120,14 @@ class ClearSiteDataType {
         throw const FormatException('Invalid value');
     }
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ClearSiteDataType && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
 
   @override
   String toString() => 'ClearSiteDataType(value: $value)';

--- a/lib/src/headers/typed/headers/connection_header.dart
+++ b/lib/src/headers/typed/headers/connection_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -54,6 +56,17 @@ final class ConnectionHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ConnectionHeader &&
+          const ListEquality<ConnectionHeaderType>()
+              .equals(directives, other.directives);
+
+  @override
+  int get hashCode =>
+      const ListEquality<ConnectionHeaderType>().hash(directives);
+
+  @override
   String toString() {
     return 'ConnectionHeader(directives: $directives)';
   }
@@ -98,6 +111,14 @@ class ConnectionHeaderType {
         throw const FormatException('Invalid value');
     }
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ConnectionHeaderType && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
 
   @override
   String toString() => 'ConnectionHeaderType(value: $value)';

--- a/lib/src/headers/typed/headers/content_disposition_header.dart
+++ b/lib/src/headers/typed/headers/content_disposition_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -59,6 +61,18 @@ final class ContentDispositionHeader {
     parts.addAll(parameters.map((final p) => p._encode()));
     return parts.join('; ');
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ContentDispositionHeader &&
+          type == other.type &&
+          const ListEquality<ContentDispositionParameter>()
+              .equals(parameters, other.parameters);
+
+  @override
+  int get hashCode => Object.hash(
+      type, const ListEquality<ContentDispositionParameter>().hash(parameters));
 
   @override
   String toString() {
@@ -140,6 +154,19 @@ class ContentDispositionParameter {
     }
     return '$name="$value"';
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ContentDispositionParameter &&
+          name == other.name &&
+          value == other.value &&
+          isExtended == other.isExtended &&
+          encoding == other.encoding &&
+          language == other.language;
+
+  @override
+  int get hashCode => Object.hash(name, value, isExtended, encoding, language);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/content_encoding_header.dart
+++ b/lib/src/headers/typed/headers/content_encoding_header.dart
@@ -18,8 +18,9 @@ final class ContentEncodingHeader {
 
   /// Constructs a [ContentEncodingHeader] instance with the specified content
   /// encodings.
-  ContentEncodingHeader({required this.encodings})
-      : assert(encodings.isNotEmpty);
+  ContentEncodingHeader({required final List<ContentEncoding> encodings})
+      : assert(encodings.isNotEmpty),
+        encodings = List.unmodifiable(encodings);
 
   /// Parses the Content-Encoding header value and returns a
   /// [ContentEncodingHeader] instance.

--- a/lib/src/headers/typed/headers/content_encoding_header.dart
+++ b/lib/src/headers/typed/headers/content_encoding_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -16,9 +18,8 @@ final class ContentEncodingHeader {
 
   /// Constructs a [ContentEncodingHeader] instance with the specified content
   /// encodings.
-  const ContentEncodingHeader({
-    required this.encodings,
-  });
+  ContentEncodingHeader({required this.encodings})
+      : assert(encodings.isNotEmpty);
 
   /// Parses the Content-Encoding header value and returns a
   /// [ContentEncodingHeader] instance.
@@ -44,6 +45,16 @@ final class ContentEncodingHeader {
   /// Converts the [ContentEncodingHeader] instance into a string representation
   /// suitable for HTTP headers.
   String _encode() => encodings.map((final e) => e.name).join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ContentEncodingHeader &&
+          const ListEquality<ContentEncoding>()
+              .equals(encodings, other.encodings);
+
+  @override
+  int get hashCode => const ListEquality<ContentEncoding>().hash(encodings);
 
   @override
   String toString() {
@@ -99,6 +110,13 @@ class ContentEncoding {
         throw const FormatException('Invalid value');
     }
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) || other is ContentEncoding && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 
   @override
   String toString() => 'ContentEncoding(name: $name)';

--- a/lib/src/headers/typed/headers/content_language_header.dart
+++ b/lib/src/headers/typed/headers/content_language_header.dart
@@ -12,11 +12,12 @@ final class ContentLanguageHeader {
       [value._encode()];
 
   /// The list of language codes specified in the header.
-  final Iterable<String> languages;
+  final List<String> languages;
 
   /// Constructs a [ContentLanguageHeader] instance with the specified language codes.
-  ContentLanguageHeader({required this.languages})
-      : assert(languages.isNotEmpty);
+  ContentLanguageHeader({required final Iterable<String> languages})
+      : assert(languages.isNotEmpty),
+        languages = List.unmodifiable(languages);
 
   /// Parses the Content-Language header value and returns a [ContentLanguageHeader] instance.
   ///
@@ -46,10 +47,10 @@ final class ContentLanguageHeader {
   bool operator ==(final Object other) =>
       identical(this, other) ||
       other is ContentLanguageHeader &&
-          const IterableEquality<String>().equals(languages, other.languages);
+          const ListEquality<String>().equals(languages, other.languages);
 
   @override
-  int get hashCode => const IterableEquality<String>().hash(languages);
+  int get hashCode => const ListEquality<String>().hash(languages);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/content_language_header.dart
+++ b/lib/src/headers/typed/headers/content_language_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -13,7 +15,8 @@ final class ContentLanguageHeader {
   final Iterable<String> languages;
 
   /// Constructs a [ContentLanguageHeader] instance with the specified language codes.
-  const ContentLanguageHeader({required this.languages});
+  ContentLanguageHeader({required this.languages})
+      : assert(languages.isNotEmpty);
 
   /// Parses the Content-Language header value and returns a [ContentLanguageHeader] instance.
   ///
@@ -38,6 +41,15 @@ final class ContentLanguageHeader {
   /// suitable for HTTP headers.
 
   String _encode() => languages.join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ContentLanguageHeader &&
+          const IterableEquality<String>().equals(languages, other.languages);
+
+  @override
+  int get hashCode => const IterableEquality<String>().hash(languages);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/content_range_header.dart
+++ b/lib/src/headers/typed/headers/content_range_header.dart
@@ -79,6 +79,18 @@ final class ContentRangeHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ContentRangeHeader &&
+          unit == other.unit &&
+          start == other.start &&
+          end == other.end &&
+          size == other.size;
+
+  @override
+  int get hashCode => Object.hash(unit, start, end, size);
+
+  @override
   String toString() {
     return 'ContentRangeHeader(unit: $unit, start: $start, end: $end, size: $size)';
   }

--- a/lib/src/headers/typed/headers/content_security_policy_header.dart
+++ b/lib/src/headers/typed/headers/content_security_policy_header.dart
@@ -18,8 +18,10 @@ final class ContentSecurityPolicyHeader {
 
   /// Constructs a [ContentSecurityPolicyHeader] instance with the specified
   /// directives.
-  ContentSecurityPolicyHeader({required this.directives})
-      : assert(directives.isNotEmpty);
+  ContentSecurityPolicyHeader(
+      {required final List<ContentSecurityPolicyDirective> directives})
+      : assert(directives.isNotEmpty),
+        directives = List.unmodifiable(directives);
 
   /// Parses a CSP header value and returns a [ContentSecurityPolicyHeader]
   /// instance.

--- a/lib/src/headers/typed/headers/content_security_policy_header.dart
+++ b/lib/src/headers/typed/headers/content_security_policy_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -16,7 +18,8 @@ final class ContentSecurityPolicyHeader {
 
   /// Constructs a [ContentSecurityPolicyHeader] instance with the specified
   /// directives.
-  const ContentSecurityPolicyHeader({required this.directives});
+  ContentSecurityPolicyHeader({required this.directives})
+      : assert(directives.isNotEmpty);
 
   /// Parses a CSP header value and returns a [ContentSecurityPolicyHeader]
   /// instance.
@@ -52,6 +55,17 @@ final class ContentSecurityPolicyHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ContentSecurityPolicyHeader &&
+          const ListEquality<ContentSecurityPolicyDirective>()
+              .equals(directives, other.directives);
+
+  @override
+  int get hashCode =>
+      const ListEquality<ContentSecurityPolicyDirective>().hash(directives);
+
+  @override
   String toString() {
     return 'ContentSecurityPolicyHeader(directives: $directives)';
   }
@@ -76,6 +90,17 @@ class ContentSecurityPolicyDirective {
   /// Converts the [ContentSecurityPolicyDirective] instance into a string
   /// representation.
   String _encode() => '$name ${values.join(' ')}';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ContentSecurityPolicyDirective &&
+          name == other.name &&
+          const IterableEquality<String>().equals(values, other.values);
+
+  @override
+  int get hashCode =>
+      Object.hash(name, const IterableEquality<String>().hash(values));
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/cookie_header.dart
+++ b/lib/src/headers/typed/headers/cookie_header.dart
@@ -14,7 +14,9 @@ final class CookieHeader {
   final List<Cookie> cookies;
 
   /// Constructs a [CookieHeader] instance with the specified cookies.
-  CookieHeader({required this.cookies}) : assert(cookies.isNotEmpty);
+  CookieHeader({required final List<Cookie> cookies})
+      : assert(cookies.isNotEmpty),
+        cookies = List.unmodifiable(cookies);
 
   /// Parses the Cookie header value and returns a [CookieHeader] instance.
   ///

--- a/lib/src/headers/typed/headers/cookie_header.dart
+++ b/lib/src/headers/typed/headers/cookie_header.dart
@@ -14,7 +14,7 @@ final class CookieHeader {
   final List<Cookie> cookies;
 
   /// Constructs a [CookieHeader] instance with the specified cookies.
-  const CookieHeader({required this.cookies});
+  CookieHeader({required this.cookies}) : assert(cookies.isNotEmpty);
 
   /// Parses the Cookie header value and returns a [CookieHeader] instance.
   ///
@@ -51,6 +51,15 @@ final class CookieHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is CookieHeader &&
+          const ListEquality<Cookie>().equals(cookies, other.cookies);
+
+  @override
+  int get hashCode => const ListEquality<Cookie>().hash(cookies);
+
+  @override
   String toString() {
     return 'CookieHeader(cookies: $cookies)';
   }
@@ -84,6 +93,14 @@ class Cookie {
 
   /// Converts the [Cookie] instance into a string representation suitable for HTTP headers.
   String _encode() => '$name=$value';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is Cookie && name == other.name && value == other.value;
+
+  @override
+  int get hashCode => Object.hash(name, value);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/cross_origin_embedder_policy_header.dart
+++ b/lib/src/headers/typed/headers/cross_origin_embedder_policy_header.dart
@@ -51,6 +51,14 @@ final class CrossOriginEmbedderPolicyHeader {
   String _encode() => policy;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is CrossOriginEmbedderPolicyHeader && policy == other.policy;
+
+  @override
+  int get hashCode => policy.hashCode;
+
+  @override
   String toString() {
     return 'CrossOriginEmbedderPolicyHeader(value: $policy)';
   }

--- a/lib/src/headers/typed/headers/cross_origin_opener_policy_header.dart
+++ b/lib/src/headers/typed/headers/cross_origin_opener_policy_header.dart
@@ -51,6 +51,14 @@ final class CrossOriginOpenerPolicyHeader {
   String _encode() => policy;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is CrossOriginOpenerPolicyHeader && policy == other.policy;
+
+  @override
+  int get hashCode => policy.hashCode;
+
+  @override
   String toString() {
     return 'CrossOriginOpenerPolicyHeader(value: $policy)';
   }

--- a/lib/src/headers/typed/headers/cross_origin_resource_policy_header.dart
+++ b/lib/src/headers/typed/headers/cross_origin_resource_policy_header.dart
@@ -49,6 +49,14 @@ final class CrossOriginResourcePolicyHeader {
   String _encode() => policy;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is CrossOriginResourcePolicyHeader && policy == other.policy;
+
+  @override
+  int get hashCode => policy.hashCode;
+
+  @override
   String toString() {
     return 'CrossOriginResourcePolicyHeader(value: $policy)';
   }

--- a/lib/src/headers/typed/headers/etag_condition_header.dart
+++ b/lib/src/headers/typed/headers/etag_condition_header.dart
@@ -5,7 +5,7 @@ import '../../extension/string_list_extensions.dart';
 import 'etag_header.dart' show InternalEx;
 
 /// Base class for ETag-based conditional headers (If-Match and If-None-Match).
-abstract class ETagConditionHeader {
+sealed class ETagConditionHeader {
   /// The list of ETags to match against.
   final List<ETagHeader> etags;
 
@@ -25,17 +25,6 @@ abstract class ETagConditionHeader {
     if (isWildcard) return '*';
     return etags.map((final e) => e.encode()).join(', ');
   }
-
-  @override
-  bool operator ==(final Object other) =>
-      identical(this, other) ||
-      other is ETagConditionHeader &&
-          isWildcard == other.isWildcard &&
-          const ListEquality<ETagHeader>().equals(etags, other.etags);
-
-  @override
-  int get hashCode =>
-      Object.hash(isWildcard, const ListEquality<ETagHeader>().hash(etags));
 }
 
 /// A class representing the HTTP If-Match header.

--- a/lib/src/headers/typed/headers/etag_condition_header.dart
+++ b/lib/src/headers/typed/headers/etag_condition_header.dart
@@ -1,6 +1,7 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
-
 import 'etag_header.dart' show InternalEx;
 
 /// Base class for ETag-based conditional headers (If-Match and If-None-Match).
@@ -24,6 +25,17 @@ abstract class ETagConditionHeader {
     if (isWildcard) return '*';
     return etags.map((final e) => e.encode()).join(', ');
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ETagConditionHeader &&
+          isWildcard == other.isWildcard &&
+          const ListEquality<ETagHeader>().equals(etags, other.etags);
+
+  @override
+  int get hashCode =>
+      Object.hash(isWildcard, const ListEquality<ETagHeader>().hash(etags));
 }
 
 /// A class representing the HTTP If-Match header.
@@ -62,6 +74,17 @@ final class IfMatchHeader extends ETagConditionHeader {
 
     return IfMatchHeader.etags(parsedEtags);
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is IfMatchHeader &&
+          isWildcard == other.isWildcard &&
+          const ListEquality<ETagHeader>().equals(etags, other.etags);
+
+  @override
+  int get hashCode =>
+      Object.hash(isWildcard, const ListEquality<ETagHeader>().hash(etags));
 
   @override
   String toString() => 'IfMatchHeader(etags: $etags, isWildcard: $isWildcard)';
@@ -104,6 +127,17 @@ final class IfNoneMatchHeader extends ETagConditionHeader {
 
     return IfNoneMatchHeader.etags(parsedEtags);
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is IfNoneMatchHeader &&
+          isWildcard == other.isWildcard &&
+          const ListEquality<ETagHeader>().equals(etags, other.etags);
+
+  @override
+  int get hashCode =>
+      Object.hash(isWildcard, const ListEquality<ETagHeader>().hash(etags));
 
   @override
   String toString() =>

--- a/lib/src/headers/typed/headers/etag_header.dart
+++ b/lib/src/headers/typed/headers/etag_header.dart
@@ -68,6 +68,14 @@ final class ETagHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ETagHeader && value == other.value && isWeak == other.isWeak;
+
+  @override
+  int get hashCode => Object.hash(value, isWeak);
+
+  @override
   String toString() {
     return 'ETagHeader(value: $value, isWeak: $isWeak)';
   }

--- a/lib/src/headers/typed/headers/expect_header.dart
+++ b/lib/src/headers/typed/headers/expect_header.dart
@@ -40,6 +40,13 @@ final class ExpectHeader {
   String _encode() => value;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) || other is ExpectHeader && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
   String toString() {
     return 'ExpectHeader(value: $value)';
   }

--- a/lib/src/headers/typed/headers/forwarded_header.dart
+++ b/lib/src/headers/typed/headers/forwarded_header.dart
@@ -182,9 +182,8 @@ final class ForwardedHeader {
   final List<ForwardedElement> elements;
 
   ForwardedHeader(final List<ForwardedElement> elements)
-      : elements = List.unmodifiable(elements);
-
-  ForwardedHeader.empty() : elements = const [];
+      : assert(elements.isNotEmpty),
+        elements = List.unmodifiable(elements);
 
   factory ForwardedHeader.parse(final Iterable<String> values) {
     final splitValues = values.splitTrimAndFilterUnique();

--- a/lib/src/headers/typed/headers/from_header.dart
+++ b/lib/src/headers/typed/headers/from_header.dart
@@ -13,10 +13,12 @@ final class FromHeader {
   static List<String> __encode(final FromHeader value) => [value._encode()];
 
   /// A list of email addresses provided in the `From` header.
-  final Iterable<String> emails;
+  final List<String> emails;
 
   /// Private constructor for initializing the [emails] list.
-  FromHeader({required this.emails}) : assert(emails.isNotEmpty);
+  FromHeader({required final Iterable<String> emails})
+      : assert(emails.isNotEmpty),
+        emails = List.unmodifiable(emails);
 
   /// Parses a `From` header value and returns a [FromHeader] instance.
   factory FromHeader.parse(final Iterable<String> values) {
@@ -46,10 +48,10 @@ final class FromHeader {
   bool operator ==(final Object other) =>
       identical(this, other) ||
       other is FromHeader &&
-          const IterableEquality<String>().equals(emails, other.emails);
+          const ListEquality<String>().equals(emails, other.emails);
 
   @override
-  int get hashCode => const IterableEquality<String>().hash(emails);
+  int get hashCode => const ListEquality<String>().hash(emails);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/from_header.dart
+++ b/lib/src/headers/typed/headers/from_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -14,7 +16,7 @@ final class FromHeader {
   final Iterable<String> emails;
 
   /// Private constructor for initializing the [emails] list.
-  FromHeader({required this.emails});
+  FromHeader({required this.emails}) : assert(emails.isNotEmpty);
 
   /// Parses a `From` header value and returns a [FromHeader] instance.
   factory FromHeader.parse(final Iterable<String> values) {
@@ -39,6 +41,15 @@ final class FromHeader {
   /// suitable for HTTP headers.
 
   String _encode() => emails.join(', ');
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is FromHeader &&
+          const IterableEquality<String>().equals(emails, other.emails);
+
+  @override
+  int get hashCode => const IterableEquality<String>().hash(emails);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/if_range_header.dart
+++ b/lib/src/headers/typed/headers/if_range_header.dart
@@ -57,6 +57,16 @@ final class IfRangeHeader {
       lastModified != null ? formatHttpDate(lastModified!) : etag!.encode();
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is IfRangeHeader &&
+          lastModified == other.lastModified &&
+          etag == other.etag;
+
+  @override
+  int get hashCode => Object.hash(lastModified, etag);
+
+  @override
   String toString() {
     return 'IfRangeHeader(lastModified: $lastModified, etag: $etag)';
   }

--- a/lib/src/headers/typed/headers/permission_policy_header.dart
+++ b/lib/src/headers/typed/headers/permission_policy_header.dart
@@ -17,8 +17,10 @@ final class PermissionsPolicyHeader {
   final List<PermissionsPolicyDirective> directives;
 
   /// Constructs a [PermissionsPolicyHeader] instance with the specified directives.
-  PermissionsPolicyHeader({required this.directives})
-      : assert(directives.isNotEmpty);
+  PermissionsPolicyHeader(
+      {required final List<PermissionsPolicyDirective> directives})
+      : assert(directives.isNotEmpty),
+        directives = List.unmodifiable(directives);
 
   /// Parses the Permissions-Policy header value and returns a [PermissionsPolicyHeader] instance.
   ///

--- a/lib/src/headers/typed/headers/permission_policy_header.dart
+++ b/lib/src/headers/typed/headers/permission_policy_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -15,7 +17,8 @@ final class PermissionsPolicyHeader {
   final List<PermissionsPolicyDirective> directives;
 
   /// Constructs a [PermissionsPolicyHeader] instance with the specified directives.
-  const PermissionsPolicyHeader({required this.directives});
+  PermissionsPolicyHeader({required this.directives})
+      : assert(directives.isNotEmpty);
 
   /// Parses the Permissions-Policy header value and returns a [PermissionsPolicyHeader] instance.
   ///
@@ -37,6 +40,7 @@ final class PermissionsPolicyHeader {
               .replaceAll(')', '')
               .split(' ')
               .map((final s) => s.trim())
+              .where((final s) => s.isNotEmpty)
               .toList()
           : <String>[];
 
@@ -57,6 +61,17 @@ final class PermissionsPolicyHeader {
   String _encode() {
     return directives.map((final directive) => directive._encode()).join(', ');
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is PermissionsPolicyHeader &&
+          const ListEquality<PermissionsPolicyDirective>()
+              .equals(directives, other.directives);
+
+  @override
+  int get hashCode =>
+      const ListEquality<PermissionsPolicyDirective>().hash(directives);
 
   @override
   String toString() {
@@ -83,6 +98,17 @@ class PermissionsPolicyDirective {
     final valuesStr = values.isNotEmpty ? '(${values.join(' ')})' : '()';
     return '$name=$valuesStr';
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is PermissionsPolicyDirective &&
+          name == other.name &&
+          const IterableEquality<String>().equals(values, other.values);
+
+  @override
+  int get hashCode =>
+      Object.hash(name, const IterableEquality<String>().hash(values));
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/range_header.dart
+++ b/lib/src/headers/typed/headers/range_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 
 /// A class representing the HTTP Range header.
@@ -19,10 +21,10 @@ final class RangeHeader {
 
   /// Constructs a [RangeHeader] instance with the specified unit and list
   /// of ranges.
-  const RangeHeader({
+  RangeHeader({
     this.unit = 'bytes',
     required this.ranges,
-  });
+  }) : assert(ranges.isNotEmpty);
 
   /// Parses the Range header value and returns a [RangeHeader] instance.
   ///
@@ -77,6 +79,17 @@ final class RangeHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is RangeHeader &&
+          unit == other.unit &&
+          const ListEquality<Range>().equals(ranges, other.ranges);
+
+  @override
+  int get hashCode =>
+      Object.hash(unit, const ListEquality<Range>().hash(ranges));
+
+  @override
   String toString() {
     return 'RangeHeader(unit: $unit, ranges: $ranges)';
   }
@@ -109,6 +122,14 @@ class Range {
     final endStr = end?.toString() ?? '';
     return '$startStr-$endStr';
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is Range && start == other.start && end == other.end;
+
+  @override
+  int get hashCode => Object.hash(start, end);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/referrer_policy_header.dart
+++ b/lib/src/headers/typed/headers/referrer_policy_header.dart
@@ -73,6 +73,14 @@ final class ReferrerPolicyHeader {
   String _encode() => directive;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is ReferrerPolicyHeader && directive == other.directive;
+
+  @override
+  int get hashCode => directive.hashCode;
+
+  @override
   String toString() {
     return 'ReferrerPolicyHeader(directive: $directive)';
   }

--- a/lib/src/headers/typed/headers/retry_after_header.dart
+++ b/lib/src/headers/typed/headers/retry_after_header.dart
@@ -73,6 +73,14 @@ final class RetryAfterHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is RetryAfterHeader && delay == other.delay && date == other.date;
+
+  @override
+  int get hashCode => Object.hash(delay, date);
+
+  @override
   String toString() {
     return 'RetryAfterHeader(delay: $delay, date: $date)';
   }

--- a/lib/src/headers/typed/headers/sec_fetch_dest_header.dart
+++ b/lib/src/headers/typed/headers/sec_fetch_dest_header.dart
@@ -129,6 +129,14 @@ final class SecFetchDestHeader {
   String _encode() => destination;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is SecFetchDestHeader && destination == other.destination;
+
+  @override
+  int get hashCode => destination.hashCode;
+
+  @override
   String toString() {
     return 'SecFetchDestHeader(value: $destination)';
   }

--- a/lib/src/headers/typed/headers/sec_fetch_mode_header.dart
+++ b/lib/src/headers/typed/headers/sec_fetch_mode_header.dart
@@ -61,6 +61,14 @@ final class SecFetchModeHeader {
   String _encode() => mode;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is SecFetchModeHeader && mode == other.mode;
+
+  @override
+  int get hashCode => mode.hashCode;
+
+  @override
   String toString() {
     return 'SecFetchModeHeader(value: $mode)';
   }

--- a/lib/src/headers/typed/headers/sec_fetch_site_header.dart
+++ b/lib/src/headers/typed/headers/sec_fetch_site_header.dart
@@ -54,6 +54,14 @@ final class SecFetchSiteHeader {
   String _encode() => site;
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is SecFetchSiteHeader && site == other.site;
+
+  @override
+  int get hashCode => site.hashCode;
+
+  @override
   String toString() {
     return 'SecFetchSiteHeader(value: $site)';
   }

--- a/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -53,7 +53,7 @@ final class SetCookieHeader {
   /// This value is `null` if the SameSite attribute is not present.
   ///
   /// See [SameSite] for more information.
-  SameSite? sameSite;
+  final SameSite? sameSite;
 
   /// Constructs a [Cookie] instance with the specified name and value.
   SetCookieHeader({
@@ -201,6 +201,33 @@ final class SetCookieHeader {
 
     return attributes.join('; ');
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is SetCookieHeader &&
+          name == other.name &&
+          value == other.value &&
+          expires == other.expires &&
+          maxAge == other.maxAge &&
+          domain == other.domain &&
+          path == other.path &&
+          secure == other.secure &&
+          httpOnly == other.httpOnly &&
+          sameSite == other.sameSite;
+
+  @override
+  int get hashCode => Object.hashAll([
+        name,
+        value,
+        expires,
+        maxAge,
+        domain,
+        path,
+        secure,
+        httpOnly,
+        sameSite,
+      ]);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/strict_transport_security_header.dart
+++ b/lib/src/headers/typed/headers/strict_transport_security_header.dart
@@ -77,6 +77,17 @@ final class StrictTransportSecurityHeader {
   }
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is StrictTransportSecurityHeader &&
+          maxAge == other.maxAge &&
+          includeSubDomains == other.includeSubDomains &&
+          preload == other.preload;
+
+  @override
+  int get hashCode => Object.hash(maxAge, includeSubDomains, preload);
+
+  @override
   String toString() {
     return 'StrictTransportSecurityHeader(maxAge: $maxAge, includeSubDomains: $includeSubDomains, preload: $preload)';
   }

--- a/lib/src/headers/typed/headers/te_header.dart
+++ b/lib/src/headers/typed/headers/te_header.dart
@@ -15,7 +15,9 @@ final class TEHeader {
   final List<TeQuality> encodings;
 
   /// Constructs a [TEHeader] instance with the specified list of encodings.
-  TEHeader({required this.encodings}) : assert(encodings.isNotEmpty);
+  TEHeader({required final List<TeQuality> encodings})
+      : assert(encodings.isNotEmpty),
+        encodings = List.unmodifiable(encodings);
 
   /// Parses the TE header value and returns a [TEHeader] instance.
   ///

--- a/lib/src/headers/typed/headers/te_header.dart
+++ b/lib/src/headers/typed/headers/te_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -13,7 +15,7 @@ final class TEHeader {
   final List<TeQuality> encodings;
 
   /// Constructs a [TEHeader] instance with the specified list of encodings.
-  TEHeader({required this.encodings});
+  TEHeader({required this.encodings}) : assert(encodings.isNotEmpty);
 
   /// Parses the TE header value and returns a [TEHeader] instance.
   ///
@@ -52,6 +54,15 @@ final class TEHeader {
   String _encode() => encodings.map((final e) => e._encode()).join(', ');
 
   @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is TEHeader &&
+          const ListEquality<TeQuality>().equals(encodings, other.encodings);
+
+  @override
+  int get hashCode => const ListEquality<TeQuality>().hash(encodings);
+
+  @override
   String toString() => 'TEHeader(encodings: $encodings)';
 }
 
@@ -68,6 +79,16 @@ class TeQuality {
 
   /// Converts the [TeQuality] instance into a string representation suitable for HTTP headers.
   String _encode() => quality == 1.0 ? encoding : '$encoding;q=$quality';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is TeQuality &&
+          encoding == other.encoding &&
+          quality == other.quality;
+
+  @override
+  int get hashCode => Object.hash(encoding, quality);
 
   @override
   String toString() => 'TeQuality(encoding: $encoding, quality: $quality)';

--- a/lib/src/headers/typed/headers/transfer_encoding_header.dart
+++ b/lib/src/headers/typed/headers/transfer_encoding_header.dart
@@ -17,7 +17,11 @@ final class TransferEncodingHeader {
   /// Constructs a [TransferEncodingHeader] instance with the specified transfer encodings.
   TransferEncodingHeader({
     required final List<TransferEncoding> encodings,
-  }) : encodings = _reorderEncodings(encodings);
+  }) : encodings = List.unmodifiable(_reorderEncodings(encodings)) {
+    if (encodings.isEmpty) {
+      throw ArgumentError.value(encodings, 'encodings', 'cannot be empty');
+    }
+  }
 
   /// Parses the Transfer-Encoding header value and returns a [TransferEncodingHeader] instance.
   ///
@@ -36,6 +40,17 @@ final class TransferEncodingHeader {
   /// Converts the [TransferEncodingHeader] instance into a string
   /// representation suitable for HTTP headers.
   String _encode() => encodings.map((final e) => e.name).join(', ');
+
+  @override
+  bool operator ==(final Object other) {
+    if (identical(this, other)) return true;
+    if (other is! TransferEncodingHeader) return false;
+    return const ListEquality<TransferEncoding>()
+        .equals(encodings, other.encodings);
+  }
+
+  @override
+  int get hashCode => const ListEquality<TransferEncoding>().hash(encodings);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/upgrade_header.dart
+++ b/lib/src/headers/typed/headers/upgrade_header.dart
@@ -15,7 +15,9 @@ final class UpgradeHeader {
   final List<UpgradeProtocol> protocols;
 
   /// Constructs an [UpgradeHeader] instance with the specified protocols.
-  UpgradeHeader({required this.protocols}) : assert(protocols.isNotEmpty);
+  UpgradeHeader({required final List<UpgradeProtocol> protocols})
+      : assert(protocols.isNotEmpty),
+        protocols = List.unmodifiable(protocols);
 
   /// Parses the Upgrade header value and returns an [UpgradeHeader] instance.
   ///

--- a/lib/src/headers/typed/headers/upgrade_header.dart
+++ b/lib/src/headers/typed/headers/upgrade_header.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../../../../relic.dart';
 import '../../extension/string_list_extensions.dart';
 
@@ -13,7 +15,7 @@ final class UpgradeHeader {
   final List<UpgradeProtocol> protocols;
 
   /// Constructs an [UpgradeHeader] instance with the specified protocols.
-  UpgradeHeader({required this.protocols});
+  UpgradeHeader({required this.protocols}) : assert(protocols.isNotEmpty);
 
   /// Parses the Upgrade header value and returns an [UpgradeHeader] instance.
   ///
@@ -37,6 +39,16 @@ final class UpgradeHeader {
   String _encode() {
     return protocols.map((final protocol) => protocol._encode()).join(', ');
   }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is UpgradeHeader &&
+          const ListEquality<UpgradeProtocol>()
+              .equals(protocols, other.protocols);
+
+  @override
+  int get hashCode => const ListEquality<UpgradeProtocol>().hash(protocols);
 
   @override
   String toString() {
@@ -93,6 +105,16 @@ class UpgradeProtocol {
 
   /// Converts the [UpgradeProtocol] instance into a string representation.
   String _encode() => '$protocol${version != null ? '/$version' : ''}';
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is UpgradeProtocol &&
+          protocol == other.protocol &&
+          version == other.version;
+
+  @override
+  int get hashCode => Object.hash(protocol, version);
 
   @override
   String toString() {

--- a/lib/src/headers/typed/headers/x_forwarded_for_header.dart
+++ b/lib/src/headers/typed/headers/x_forwarded_for_header.dart
@@ -20,7 +20,11 @@ final class XForwardedForHeader {
 
   /// Creates an [XForwardedForHeader] with the given list of addresses.
   XForwardedForHeader(final Iterable<String> addresses)
-      : addresses = List.unmodifiable(addresses);
+      : addresses = List.unmodifiable(addresses) {
+    if (addresses.isEmpty) {
+      throw ArgumentError.value(addresses, 'addresses', 'cannot be empty');
+    }
+  }
 
   /// Parses the `X-Forwarded-For` header values into an [XForwardedForHeader].
   factory XForwardedForHeader.parse(final Iterable<String> values) {

--- a/lib/src/headers/typed/typed_headers.dart
+++ b/lib/src/headers/typed/typed_headers.dart
@@ -39,3 +39,4 @@ export 'headers/te_header.dart';
 export 'headers/transfer_encoding_header.dart';
 export 'headers/upgrade_header.dart';
 export 'headers/vary_header.dart';
+export 'headers/x_forwarded_for_header.dart';

--- a/lib/src/method/request_method.dart
+++ b/lib/src/method/request_method.dart
@@ -1,34 +1,21 @@
 import '../../relic.dart';
 
 /// Represents the HTTP methods used in requests as constants.
-class RequestMethod {
+enum RequestMethod {
   /// Predefined HTTP method constants.
-  static const _get = 'GET';
-  static const _post = 'POST';
-  static const _put = 'PUT';
-  static const _delete = 'DELETE';
-  static const _patch = 'PATCH';
-  static const _head = 'HEAD';
-  static const _options = 'OPTIONS';
-  static const _trace = 'TRACE';
-  static const _connect = 'CONNECT';
+  get,
+  post,
+  put,
+  delete,
+  patch,
+  head,
+  options,
+  trace,
+  connect;
 
-  /// The string representation of the HTTP method.
-  final String value;
-
-  /// Creates a new [RequestMethod] instance with the given HTTP method [value].
-  const RequestMethod._(this.value);
-
-  /// Predefined HTTP method constants.
-  static const get = RequestMethod._(_get);
-  static const post = RequestMethod._(_post);
-  static const put = RequestMethod._(_put);
-  static const delete = RequestMethod._(_delete);
-  static const patch = RequestMethod._(_patch);
-  static const head = RequestMethod._(_head);
-  static const options = RequestMethod._(_options);
-  static const trace = RequestMethod._(_trace);
-  static const connect = RequestMethod._(_connect);
+  static final _reverseMap = <String, RequestMethod>{
+    for (final r in values) r.name: r
+  };
 
   /// Parses a [method] string and returns the corresponding [RequestMethod] instance.
   ///
@@ -40,32 +27,12 @@ class RequestMethod {
       throw const FormatException('Value cannot be empty');
     }
 
-    switch (method.toUpperCase()) {
-      case _get:
-        return get;
-      case _post:
-        return post;
-      case _put:
-        return put;
-      case _delete:
-        return delete;
-      case _patch:
-        return patch;
-      case _head:
-        return head;
-      case _options:
-        return options;
-      case _trace:
-        return trace;
-      case _connect:
-        return connect;
-      default:
-        throw const FormatException('Invalid value');
-    }
+    return _reverseMap[method.trim().toLowerCase()] ??
+        (throw FormatException('Invalid value', method));
   }
-  static const codec = HeaderCodec.single(RequestMethod.parse, __encode);
-  static List<String> __encode(final RequestMethod value) => [value.toString()];
 
-  @override
-  String toString() => 'Method($value)';
+  String get value => name.toUpperCase();
+
+  static const codec = HeaderCodec.single(RequestMethod.parse, __encode);
+  static List<String> __encode(final RequestMethod value) => [value.value];
 }

--- a/lib/src/middleware/routing_middleware.dart
+++ b/lib/src/middleware/routing_middleware.dart
@@ -82,7 +82,6 @@ extension on RequestMethod {
       RequestMethod.patch => Method.patch,
       RequestMethod.trace => Method.trace,
       RequestMethod.connect => Method.connect,
-      _ => throw UnimplementedError(),
     };
   }
 }

--- a/test/headers/basic/via_header_test.dart
+++ b/test/headers/basic/via_header_test.dart
@@ -15,6 +15,7 @@ void main() {
     });
 
     tearDown(() => server.close());
+
     test(
       'when an empty Via header is passed then the server responds '
       'with a bad request including a message that states the header value '

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -608,8 +608,8 @@ void main() {
       ),
       (
         Headers.clearSiteData,
-        (final h) => h.clearSiteData = const ClearSiteDataHeader.dataTypes(
-            dataTypes: [ClearSiteDataType.cache])
+        (final h) => h.clearSiteData =
+            ClearSiteDataHeader.dataTypes(dataTypes: [ClearSiteDataType.cache])
       ),
       (
         Headers.connection,

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -480,11 +480,12 @@ void main() {
         final header2 = v.accessor.getValueFrom(headers2);
         expect(header1, isNotNull);
         expect(header2, isNotNull);
-        //expect(identical(header1, header2), isFalse);
+
         expect(header1, equals(header1));
         if (header1 is! List) {
           expect(header1, equals(header2));
-          expect(header1.hashCode, equals(header2.hashCode));
+          expect(header1.hashCode, equals(header2.hashCode),
+              reason: 'hashCode for: $header1');
         }
 
         final raw = v.accessor.codec.encode(header1!);
@@ -549,6 +550,12 @@ void main() {
         Headers.accessControlAllowMethods,
         (final h) => h.accessControlAllowMethods =
             const AccessControlAllowMethodsHeader.wildcard()
+      ),
+      (
+        Headers.accessControlAllowMethods,
+        (final h) => h.accessControlAllowMethods =
+            AccessControlAllowMethodsHeader.methods(
+                methods: RequestMethod.values)
       ),
       (
         Headers.accessControlAllowOrigin,

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -1,5 +1,4 @@
 import 'package:relic/relic.dart';
-import 'package:relic/src/headers/typed/headers/x_forwarded_for_header.dart';
 import 'package:test/test.dart';
 
 import '../util/test_util.dart';
@@ -526,7 +525,7 @@ void main() {
               origin: Uri.parse('https://example.com')),
       Headers.accessControlExposeHeaders: (final h) =>
           h.accessControlExposeHeaders =
-              const AccessControlExposeHeadersHeader.headers(headers: ['foo']),
+              AccessControlExposeHeadersHeader.headers(headers: ['foo']),
       Headers.accessControlMaxAge: (final h) => h.accessControlMaxAge = 42,
       Headers.accessControlRequestHeaders: (final h) =>
           h.accessControlRequestHeaders = ['foo'],
@@ -545,9 +544,9 @@ void main() {
       Headers.contentDisposition: (final h) => h.contentDisposition =
           ContentDispositionHeader.parse('attachment; filename="report.pdf"'),
       Headers.contentEncoding: (final h) => h.contentEncoding =
-          const ContentEncodingHeader(encodings: [ContentEncoding.gzip]),
+          ContentEncodingHeader(encodings: [ContentEncoding.gzip]),
       Headers.contentLanguage: (final h) =>
-          h.contentLanguage = const ContentLanguageHeader(languages: ['en']),
+          h.contentLanguage = ContentLanguageHeader(languages: ['en']),
       Headers.contentLength: (final h) => h.contentLength = 1202,
       Headers.contentLocation: (final h) =>
           h.contentLocation = Uri.parse('https://example.com'),
@@ -588,8 +587,8 @@ void main() {
       Headers.maxForwards: (final h) => h.maxForwards = 42,
       Headers.origin: (final h) => h.origin = Uri.parse('https://example.com'),
       Headers.permissionsPolicy: (final h) => h.permissionsPolicy =
-              const PermissionsPolicyHeader(directives: [
-            PermissionsPolicyDirective(name: 'foo', values: [])
+              PermissionsPolicyHeader(directives: [
+            const PermissionsPolicyDirective(name: 'foo', values: [])
           ]),
       Headers.proxyAuthenticate: (final h) => h.proxyAuthenticate =
           const AuthenticationHeader(

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -451,20 +451,20 @@ void main() {
   );
 
   parameterizedGroup(
-    (final v) => 'Given a "${v.key.key}" header ',
+    (final v) => 'Given a "${v.accessor.key}" header ',
     (final v) {
       test(
           'when using the named extension property on an empty MutableHeaders instance '
           'then setting to value succeeds', () {
-        expect(() => Headers.build(v.value), returnsNormally);
+        expect(() => Headers.build(v.mutator), returnsNormally);
       });
 
       test('when round-tripping', () {
-        final headers1 = Headers.build(v.value);
-        final header1 = v.key.getValueFrom(headers1);
+        final headers1 = Headers.build(v.mutator);
+        final header1 = v.accessor.getValueFrom(headers1);
 
-        final raw = v.key.codec.encode(header1!);
-        final header3 = v.key.codec.decode(raw);
+        final raw = v.accessor.codec.encode(header1!);
+        final header3 = v.accessor.codec.decode(raw);
         if (header1 is! List) {
           expect(header1, equals(header3));
           expect(header1.hashCode, equals(header3.hashCode));
@@ -472,12 +472,12 @@ void main() {
       });
 
       test('when comparing', () {
-        final headers1 = Headers.build(v.value);
-        final headers2 = Headers.build(v.value);
+        final headers1 = Headers.build(v.mutator);
+        final headers2 = Headers.build(v.mutator);
         expect(identical(headers1, headers2), isFalse);
 
-        final header1 = v.key.getValueFrom(headers1);
-        final header2 = v.key.getValueFrom(headers2);
+        final header1 = v.accessor.getValueFrom(headers1);
+        final header2 = v.accessor.getValueFrom(headers2);
         expect(header1, isNotNull);
         expect(header2, isNotNull);
         //expect(identical(header1, header2), isFalse);
@@ -487,154 +487,327 @@ void main() {
           expect(header1.hashCode, equals(header2.hashCode));
         }
 
-        final raw = v.key.codec.encode(header1!);
-        final header3 = v.key.codec.decode(raw);
+        final raw = v.accessor.codec.encode(header1!);
+        final header3 = v.accessor.codec.decode(raw);
         if (header1 is! List) {
           expect(header1, equals(header3));
           expect(header1.hashCode, equals(header3.hashCode));
         }
-        final headers4 = Headers.build((final mh) => mh[v.key.key] = raw);
-        expect(v.key.isSetIn(headers4), isTrue);
-        expect(v.key.isValidIn(headers4), isTrue);
-        final header4 = v.key.getValueFrom(headers4);
+        final headers4 = Headers.build((final mh) => mh[v.accessor.key] = raw);
+        expect(v.accessor.isSetIn(headers4), isTrue);
+        expect(v.accessor.isValidIn(headers4), isTrue);
+        final header4 = v.accessor.getValueFrom(headers4);
         if (header1 is! List) {
           expect(header1, equals(header4));
           expect(header1.hashCode, equals(header4.hashCode));
         }
       });
     },
-    variants: <HeaderAccessor, dynamic Function(MutableHeaders)>{
-      Headers.accept: (final h) =>
-          h.accept = AcceptHeader.parse(['application/vnd.example.api+json']),
-      Headers.acceptEncoding: (final h) =>
-          h.acceptEncoding = const AcceptEncodingHeader.wildcard(),
-      Headers.acceptLanguage: (final h) =>
-          h.acceptLanguage = const AcceptLanguageHeader.wildcard(),
-      Headers.acceptRanges: (final h) =>
-          h.acceptRanges = AcceptRangesHeader.none(),
-      Headers.accessControlAllowCredentials: (final h) =>
-          h.accessControlAllowCredentials = true,
-      Headers.accessControlAllowHeaders: (final h) =>
-          h.accessControlAllowHeaders =
-              const AccessControlAllowHeadersHeader.wildcard(),
-      Headers.accessControlAllowMethods: (final h) =>
-          h.accessControlAllowMethods =
-              const AccessControlAllowMethodsHeader.wildcard(),
-      Headers.accessControlAllowOrigin: (final h) =>
-          h.accessControlAllowOrigin = AccessControlAllowOriginHeader.origin(
-              origin: Uri.parse('https://example.com')),
-      Headers.accessControlExposeHeaders: (final h) =>
-          h.accessControlExposeHeaders =
-              AccessControlExposeHeadersHeader.headers(headers: ['foo']),
-      Headers.accessControlMaxAge: (final h) => h.accessControlMaxAge = 42,
-      Headers.accessControlRequestHeaders: (final h) =>
-          h.accessControlRequestHeaders = ['foo'],
-      Headers.accessControlRequestMethod: (final h) =>
-          h.accessControlRequestMethod = RequestMethod.get,
-      Headers.age: (final h) => h.age = 42,
-      Headers.allow: (final h) => h.allow = [RequestMethod.get],
-      Headers.authorization: (final h) =>
-          h.authorization = BearerAuthorizationHeader(token: 'foobar'),
-      Headers.cacheControl: (final h) =>
-          h.cacheControl = CacheControlHeader.parse(['max-age=3600']),
-      Headers.clearSiteData: (final h) =>
-          h.clearSiteData = const ClearSiteDataHeader.wildcard(),
-      Headers.connection: (final h) => h.connection =
-          const ConnectionHeader(directives: [ConnectionHeaderType.keepAlive]),
-      Headers.contentDisposition: (final h) => h.contentDisposition =
-          ContentDispositionHeader.parse('attachment; filename="report.pdf"'),
-      Headers.contentEncoding: (final h) => h.contentEncoding =
-          ContentEncodingHeader(encodings: [ContentEncoding.gzip]),
-      Headers.contentLanguage: (final h) =>
-          h.contentLanguage = ContentLanguageHeader(languages: ['en']),
-      Headers.contentLength: (final h) => h.contentLength = 1202,
-      Headers.contentLocation: (final h) =>
-          h.contentLocation = Uri.parse('https://example.com'),
-      Headers.contentRange: (final h) => h.contentRange = ContentRangeHeader(),
-      Headers.contentSecurityPolicy: (final h) => h.contentSecurityPolicy =
-              ContentSecurityPolicyHeader(directives: [
-            ContentSecurityPolicyDirective(name: 'foo', values: [])
-          ]),
-      Headers.cookie: (final h) =>
-          h.cookie = CookieHeader(cookies: [Cookie(name: 'foo', value: 'bar')]),
-      Headers.crossOriginEmbedderPolicy: (final h) =>
-          h.crossOriginEmbedderPolicy =
-              CrossOriginEmbedderPolicyHeader.unsafeNone,
-      Headers.crossOriginOpenerPolicy: (final h) =>
-          h.crossOriginOpenerPolicy = CrossOriginOpenerPolicyHeader.unsafeNone,
-      Headers.crossOriginResourcePolicy: (final h) => h
-          .crossOriginResourcePolicy = CrossOriginResourcePolicyHeader.sameSite,
-      Headers.date: (final h) => h.date = DateTime.utc(2025, 9, 23),
-      Headers.etag: (final h) => h.etag = const ETagHeader(value: ''),
-      Headers.expect: (final h) => h.expect = ExpectHeader.continue100,
-      Headers.expires: (final h) => h.expires = DateTime.utc(2025, 9, 23),
-      Headers.from: (final h) =>
-          h.from = FromHeader(emails: ['info@serverpod.com']),
-      Headers.host: (final h) => h.host = Uri.parse('https://example.com'),
-      Headers.ifMatch: (final h) => h.ifMatch = const IfMatchHeader.wildcard(),
-      Headers.ifModifiedSince: (final h) =>
-          h.ifModifiedSince = DateTime.utc(2025, 9, 23),
-      Headers.ifNoneMatch: (final h) =>
-          h.ifNoneMatch = const IfNoneMatchHeader.wildcard(),
-      Headers.ifRange: (final h) =>
-          h.ifRange = IfRangeHeader(lastModified: DateTime.utc(2025, 9, 23)),
-      Headers.ifUnmodifiedSince: (final h) =>
-          h.ifUnmodifiedSince = DateTime.utc(2025, 9, 23),
-      Headers.lastModified: (final h) =>
-          h.lastModified = DateTime.utc(2025, 9, 23),
-      Headers.location: (final h) =>
-          h.location = Uri.parse('https://example.com'),
-      Headers.maxForwards: (final h) => h.maxForwards = 42,
-      Headers.origin: (final h) => h.origin = Uri.parse('https://example.com'),
-      Headers.permissionsPolicy: (final h) => h.permissionsPolicy =
-              PermissionsPolicyHeader(directives: [
-            const PermissionsPolicyDirective(name: 'foo', values: [])
-          ]),
-      Headers.proxyAuthenticate: (final h) => h.proxyAuthenticate =
-          AuthenticationHeader(
-              scheme: 'Bearer',
-              parameters: [const AuthenticationParameter('foo', 'bar')]),
-      Headers.proxyAuthorization: (final h) =>
-          h.proxyAuthorization = BearerAuthorizationHeader(token: 'foobar'),
-      Headers.range: (final h) =>
-          h.range = RangeHeader(ranges: [Range(start: 1)]),
-      Headers.referer: (final h) =>
-          h.referer = Uri.parse('https://example.com'),
-      Headers.referrerPolicy: (final h) =>
-          h.referrerPolicy = ReferrerPolicyHeader.origin,
-      Headers.retryAfter: (final h) =>
-          h.retryAfter = RetryAfterHeader(delay: 1),
-      Headers.secFetchDest: (final h) =>
-          h.secFetchDest = SecFetchDestHeader.audio,
-      Headers.secFetchMode: (final h) =>
-          h.secFetchMode = SecFetchModeHeader.cors,
-      Headers.secFetchSite: (final h) =>
-          h.secFetchSite = SecFetchSiteHeader.crossSite,
-      Headers.server: (final h) => h.server = 'localhost',
-      Headers.setCookie: (final h) =>
-          h.setCookie = SetCookieHeader(name: 'foo', value: 'bar'),
-      Headers.strictTransportSecurity: (final h) =>
-          h.strictTransportSecurity = StrictTransportSecurityHeader(maxAge: 42),
-      Headers.te: (final h) => h.te = TEHeader(encodings: [TeQuality('foo')]),
-      Headers.trailer: (final h) => h.trailer = ['foo'],
-      Headers.transferEncoding: (final h) => h.transferEncoding =
-          TransferEncodingHeader(encodings: [TransferEncoding.gzip]),
-      Headers.upgrade: (final h) => h.upgrade =
-          UpgradeHeader(protocols: [UpgradeProtocol(protocol: 'foo')]),
-      Headers.userAgent: (final h) => h.userAgent = 'null',
-      Headers.vary: (final h) => h.vary = VaryHeader.wildcard(),
-      Headers.via: (final h) => h.via = ['foo'],
-      Headers.wwwAuthenticate: (final h) => h.wwwAuthenticate =
-          AuthenticationHeader(
-              scheme: 'Bearer',
-              parameters: [const AuthenticationParameter('foo', 'bar')]),
-      Headers.xPoweredBy: (final h) => h.xPoweredBy = 'null',
-      Headers.forwarded: (final h) => h.forwarded = ForwardedHeader([
-            ForwardedElement(
-                forwardedFor: const ForwardedIdentifier('192.1.0.1'))
-          ]),
-      Headers.xForwardedFor: (final h) =>
-          h.xForwardedFor = XForwardedForHeader(['192.1.0.1']),
-    }.entries,
+    variants: <(HeaderAccessor, void Function(MutableHeaders))>[
+      (
+        Headers.accept,
+        (final h) =>
+            h.accept = AcceptHeader.parse(['application/vnd.example.api+json'])
+      ),
+      (
+        Headers.acceptEncoding,
+        (final h) => h.acceptEncoding = const AcceptEncodingHeader.wildcard()
+      ),
+      (
+        Headers.acceptEncoding,
+        (final h) => h.acceptEncoding = AcceptEncodingHeader.encodings(
+            encodings: [EncodingQuality('jpeg', 0.5)])
+      ),
+      (
+        Headers.acceptLanguage,
+        (final h) => h.acceptLanguage = const AcceptLanguageHeader.wildcard()
+      ),
+      (
+        Headers.acceptLanguage,
+        (final h) => h.acceptLanguage = AcceptLanguageHeader.languages(
+            languages: [const LanguageQuality('en', 1.0)])
+      ),
+      (
+        Headers.acceptRanges,
+        (final h) => h.acceptRanges = AcceptRangesHeader.none()
+      ),
+      (
+        Headers.accessControlAllowCredentials,
+        (final h) => h.accessControlAllowCredentials = true
+      ),
+      (
+        Headers.accessControlAllowHeaders,
+        (final h) => h.accessControlAllowHeaders =
+            const AccessControlAllowHeadersHeader.wildcard()
+      ),
+      (
+        Headers.accessControlAllowHeaders,
+        (final h) => h.accessControlAllowHeaders =
+            AccessControlAllowHeadersHeader.headers(headers: ['foo'])
+      ),
+      (
+        Headers.accessControlAllowMethods,
+        (final h) => h.accessControlAllowMethods =
+            const AccessControlAllowMethodsHeader.wildcard()
+      ),
+      (
+        Headers.accessControlAllowOrigin,
+        (final h) => h.accessControlAllowOrigin =
+            AccessControlAllowOriginHeader.origin(
+                origin: Uri.parse('https://example.com'))
+      ),
+      (
+        Headers.accessControlExposeHeaders,
+        (final h) => h.accessControlExposeHeaders =
+            AccessControlExposeHeadersHeader.headers(headers: ['foo'])
+      ),
+      (Headers.accessControlMaxAge, (final h) => h.accessControlMaxAge = 42),
+      (
+        Headers.accessControlRequestHeaders,
+        (final h) => h.accessControlRequestHeaders = ['foo']
+      ),
+      (
+        Headers.accessControlRequestMethod,
+        (final h) => h.accessControlRequestMethod = RequestMethod.get
+      ),
+      (Headers.age, (final h) => h.age = 42),
+      (Headers.allow, (final h) => h.allow = [RequestMethod.get]),
+      (
+        Headers.authorization,
+        (final h) =>
+            h.authorization = BearerAuthorizationHeader(token: 'foobar')
+      ),
+      (
+        Headers.authorization,
+        (final h) => h.authorization =
+            BasicAuthorizationHeader(username: 'foo', password: 'bar')
+      ),
+      (
+        Headers.authorization,
+        (final h) => h.authorization = DigestAuthorizationHeader(
+            username: 'foo',
+            realm: 'bar',
+            nonce: 'random',
+            uri: 'https://example.com',
+            response: 'modnar')
+      ),
+      (
+        Headers.cacheControl,
+        (final h) => h.cacheControl = CacheControlHeader.parse(['max-age=3600'])
+      ),
+      (
+        Headers.clearSiteData,
+        (final h) => h.clearSiteData = const ClearSiteDataHeader.wildcard()
+      ),
+      (
+        Headers.clearSiteData,
+        (final h) => h.clearSiteData = const ClearSiteDataHeader.dataTypes(
+            dataTypes: [ClearSiteDataType.cache])
+      ),
+      (
+        Headers.connection,
+        (final h) => h.connection =
+            const ConnectionHeader(directives: [ConnectionHeaderType.keepAlive])
+      ),
+      (
+        Headers.contentDisposition,
+        (final h) => h.contentDisposition =
+            ContentDispositionHeader.parse('attachment; filename="report.pdf"')
+      ),
+      (
+        Headers.contentDisposition,
+        (final h) {
+          h.contentDisposition = const ContentDispositionHeader(
+            type: 'attachment',
+            parameters: [
+              ContentDispositionParameter(
+                  name: 'filename', value: 'report.pdf', isExtended: true)
+            ],
+          );
+        }
+      ),
+      (
+        Headers.contentEncoding,
+        (final h) => h.contentEncoding =
+            ContentEncodingHeader(encodings: [ContentEncoding.gzip])
+      ),
+      (
+        Headers.contentLanguage,
+        (final h) =>
+            h.contentLanguage = ContentLanguageHeader(languages: ['en'])
+      ),
+      (Headers.contentLength, (final h) => h.contentLength = 1202),
+      (
+        Headers.contentLocation,
+        (final h) => h.contentLocation = Uri.parse('https://example.com')
+      ),
+      (
+        Headers.contentRange,
+        (final h) => h.contentRange = ContentRangeHeader()
+      ),
+      (
+        Headers.contentSecurityPolicy,
+        (final h) => h.contentSecurityPolicy = ContentSecurityPolicyHeader(
+                directives: [
+                  ContentSecurityPolicyDirective(name: 'foo', values: [])
+                ])
+      ),
+      (
+        Headers.cookie,
+        (final h) => h.cookie =
+            CookieHeader(cookies: [Cookie(name: 'foo', value: 'bar')])
+      ),
+      (
+        Headers.crossOriginEmbedderPolicy,
+        (final h) => h.crossOriginEmbedderPolicy =
+            CrossOriginEmbedderPolicyHeader.unsafeNone
+      ),
+      (
+        Headers.crossOriginOpenerPolicy,
+        (final h) =>
+            h.crossOriginOpenerPolicy = CrossOriginOpenerPolicyHeader.unsafeNone
+      ),
+      (
+        Headers.crossOriginResourcePolicy,
+        (final h) => h.crossOriginResourcePolicy =
+            CrossOriginResourcePolicyHeader.sameSite
+      ),
+      (Headers.date, (final h) => h.date = DateTime.utc(2025, 9, 23)),
+      (Headers.etag, (final h) => h.etag = const ETagHeader(value: '')),
+      (Headers.expect, (final h) => h.expect = ExpectHeader.continue100),
+      (Headers.expires, (final h) => h.expires = DateTime.utc(2025, 9, 23)),
+      (
+        Headers.from,
+        (final h) => h.from = FromHeader(emails: ['info@serverpod.com'])
+      ),
+      (Headers.host, (final h) => h.host = Uri.parse('www.example.com:80')),
+      (
+        Headers.ifMatch,
+        (final h) => h.ifMatch = const IfMatchHeader.wildcard()
+      ),
+      (
+        Headers.ifMatch,
+        (final h) =>
+            h.ifMatch = const IfMatchHeader.etags([ETagHeader(value: 'foobar')])
+      ),
+      (
+        Headers.ifModifiedSince,
+        (final h) => h.ifModifiedSince = DateTime.utc(2025, 9, 23)
+      ),
+      (
+        Headers.ifNoneMatch,
+        (final h) => h.ifNoneMatch = const IfNoneMatchHeader.wildcard()
+      ),
+      (
+        Headers.ifRange,
+        (final h) =>
+            h.ifRange = IfRangeHeader(lastModified: DateTime.utc(2025, 9, 23))
+      ),
+      (
+        Headers.ifUnmodifiedSince,
+        (final h) => h.ifUnmodifiedSince = DateTime.utc(2025, 9, 23)
+      ),
+      (
+        Headers.lastModified,
+        (final h) => h.lastModified = DateTime.utc(2025, 9, 23)
+      ),
+      (
+        Headers.location,
+        (final h) => h.location = Uri.parse('https://example.com')
+      ),
+      (Headers.maxForwards, (final h) => h.maxForwards = 42),
+      (
+        Headers.origin,
+        (final h) => h.origin = Uri.parse('https://example.com')
+      ),
+      (
+        Headers.permissionsPolicy,
+        (final h) => h.permissionsPolicy = PermissionsPolicyHeader(directives: [
+              const PermissionsPolicyDirective(name: 'foo', values: [])
+            ])
+      ),
+      (
+        Headers.proxyAuthenticate,
+        (final h) => h.proxyAuthenticate = AuthenticationHeader(
+            scheme: 'Bearer',
+            parameters: [const AuthenticationParameter('foo', 'bar')])
+      ),
+      (
+        Headers.proxyAuthorization,
+        (final h) =>
+            h.proxyAuthorization = BearerAuthorizationHeader(token: 'foobar')
+      ),
+      (
+        Headers.range,
+        (final h) => h.range = RangeHeader(ranges: [Range(start: 1)])
+      ),
+      (
+        Headers.referer,
+        (final h) => h.referer = Uri.parse('https://example.com')
+      ),
+      (
+        Headers.referrerPolicy,
+        (final h) => h.referrerPolicy = ReferrerPolicyHeader.origin
+      ),
+      (
+        Headers.retryAfter,
+        (final h) => h.retryAfter = RetryAfterHeader(delay: 1)
+      ),
+      (
+        Headers.secFetchDest,
+        (final h) => h.secFetchDest = SecFetchDestHeader.audio
+      ),
+      (
+        Headers.secFetchMode,
+        (final h) => h.secFetchMode = SecFetchModeHeader.cors
+      ),
+      (
+        Headers.secFetchSite,
+        (final h) => h.secFetchSite = SecFetchSiteHeader.crossSite
+      ),
+      (Headers.server, (final h) => h.server = 'localhost'),
+      (
+        Headers.setCookie,
+        (final h) => h.setCookie = SetCookieHeader(name: 'foo', value: 'bar')
+      ),
+      (
+        Headers.strictTransportSecurity,
+        (final h) => h.strictTransportSecurity =
+            StrictTransportSecurityHeader(maxAge: 42)
+      ),
+      (Headers.te, (final h) => h.te = TEHeader(encodings: [TeQuality('foo')])),
+      (Headers.trailer, (final h) => h.trailer = ['foo']),
+      (
+        Headers.transferEncoding,
+        (final h) => h.transferEncoding =
+            TransferEncodingHeader(encodings: [TransferEncoding.gzip])
+      ),
+      (
+        Headers.upgrade,
+        (final h) => h.upgrade =
+            UpgradeHeader(protocols: [UpgradeProtocol(protocol: 'foo')])
+      ),
+      (Headers.userAgent, (final h) => h.userAgent = 'null'),
+      (Headers.vary, (final h) => h.vary = VaryHeader.wildcard()),
+      (Headers.via, (final h) => h.via = ['foo']),
+      (
+        Headers.wwwAuthenticate,
+        (final h) => h.wwwAuthenticate = AuthenticationHeader(
+            scheme: 'Bearer',
+            parameters: [const AuthenticationParameter('foo', 'bar')])
+      ),
+      (Headers.xPoweredBy, (final h) => h.xPoweredBy = 'null'),
+      (
+        Headers.forwarded,
+        (final h) => h.forwarded = ForwardedHeader([
+              ForwardedElement(
+                  forwardedFor: const ForwardedIdentifier('192.1.0.1'))
+            ])
+      ),
+      (
+        Headers.xForwardedFor,
+        (final h) => h.xForwardedFor = XForwardedForHeader(['192.1.0.1'])
+      ),
+    ].map((final r) => (accessor: r.$1, mutator: r.$2)),
   );
 }

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -507,7 +507,7 @@ void main() {
       Headers.accept: (final h) =>
           h.accept = AcceptHeader.parse(['application/vnd.example.api+json']),
       Headers.acceptEncoding: (final h) =>
-          h.acceptEncoding = AcceptEncodingHeader.wildcard(),
+          h.acceptEncoding = const AcceptEncodingHeader.wildcard(),
       Headers.acceptLanguage: (final h) =>
           h.acceptLanguage = const AcceptLanguageHeader.wildcard(),
       Headers.acceptRanges: (final h) =>
@@ -591,9 +591,9 @@ void main() {
             const PermissionsPolicyDirective(name: 'foo', values: [])
           ]),
       Headers.proxyAuthenticate: (final h) => h.proxyAuthenticate =
-          const AuthenticationHeader(
+          AuthenticationHeader(
               scheme: 'Bearer',
-              parameters: [AuthenticationParameter('foo', 'bar')]),
+              parameters: [const AuthenticationParameter('foo', 'bar')]),
       Headers.proxyAuthorization: (final h) =>
           h.proxyAuthorization = BearerAuthorizationHeader(token: 'foobar'),
       Headers.range: (final h) =>
@@ -625,9 +625,9 @@ void main() {
       Headers.vary: (final h) => h.vary = VaryHeader.wildcard(),
       Headers.via: (final h) => h.via = ['foo'],
       Headers.wwwAuthenticate: (final h) => h.wwwAuthenticate =
-          const AuthenticationHeader(
+          AuthenticationHeader(
               scheme: 'Bearer',
-              parameters: [AuthenticationParameter('foo', 'bar')]),
+              parameters: [const AuthenticationParameter('foo', 'bar')]),
       Headers.xPoweredBy: (final h) => h.xPoweredBy = 'null',
       Headers.forwarded: (final h) => h.forwarded = ForwardedHeader([
             ForwardedElement(

--- a/test/headers/typed/accept_encoding_header_test.dart
+++ b/test/headers/typed/accept_encoding_header_test.dart
@@ -129,7 +129,7 @@ void main() {
 
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.encoding)
+              .map((final e) => e.encoding)
               .toList(),
           equals(['gzip']),
         );
@@ -148,7 +148,7 @@ void main() {
 
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.quality)
+              .map((final e) => e.quality)
               .toList(),
           equals([1.0]),
         );
@@ -167,7 +167,7 @@ void main() {
 
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.quality)
+              .map((final e) => e.quality)
               .toList(),
           equals([0.5]),
         );
@@ -186,7 +186,7 @@ void main() {
 
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.encoding)
+              .map((final e) => e.encoding)
               .toList(),
           equals(['gzip']),
         );
@@ -220,13 +220,13 @@ void main() {
 
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.encoding)
+              .map((final e) => e.encoding)
               .toList(),
           equals(['*']),
         );
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.quality)
+              .map((final e) => e.quality)
               .toList(),
           equals([0.5]),
         );
@@ -244,13 +244,13 @@ void main() {
 
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.encoding)
+              .map((final e) => e.encoding)
               .toList(),
           equals(['gzip']),
         );
         expect(
           headers.acceptEncoding?.encodings
-              ?.map((final e) => e.quality)
+              .map((final e) => e.quality)
               .toList(),
           equals([1.0]),
         );
@@ -269,7 +269,7 @@ void main() {
 
           expect(
             headers.acceptEncoding?.encodings
-                ?.map((final e) => e.encoding)
+                .map((final e) => e.encoding)
                 .toList(),
             equals(['gzip', 'deflate', 'br']),
           );
@@ -287,7 +287,7 @@ void main() {
 
           expect(
             headers.acceptEncoding?.encodings
-                ?.map((final e) => e.encoding)
+                .map((final e) => e.encoding)
                 .toList(),
             equals(['gzip', 'deflate', 'br']),
           );
@@ -305,7 +305,7 @@ void main() {
 
           expect(
             headers.acceptEncoding?.encodings
-                ?.map((final e) => e.quality)
+                .map((final e) => e.quality)
                 .toList(),
             equals([1.0, 0.5, 0.8]),
           );
@@ -324,7 +324,7 @@ void main() {
 
           expect(
             headers.acceptEncoding?.encodings
-                ?.map((final e) => e.encoding)
+                .map((final e) => e.encoding)
                 .toList(),
             equals(['gzip', 'deflate', 'br']),
           );
@@ -342,7 +342,7 @@ void main() {
 
           expect(
             headers.acceptEncoding?.encodings
-                ?.map((final e) => e.encoding)
+                .map((final e) => e.encoding)
                 .toList(),
             equals(['gzip', 'deflate', 'br']),
           );

--- a/test/headers/typed/accept_encoding_header_test.dart
+++ b/test/headers/typed/accept_encoding_header_test.dart
@@ -204,7 +204,7 @@ void main() {
         );
 
         expect(headers.acceptEncoding?.isWildcard, isTrue);
-        expect(headers.acceptEncoding?.encodings, isNull);
+        expect(headers.acceptEncoding?.encodings, isEmpty);
       },
     );
 

--- a/test/headers/typed/accept_language_test.dart
+++ b/test/headers/typed/accept_language_test.dart
@@ -133,7 +133,7 @@ void main() {
 
           expect(
             headers.acceptLanguage?.languages
-                ?.map((final e) => e.language)
+                .map((final e) => e.language)
                 .toList(),
             equals(['en']),
           );
@@ -152,7 +152,7 @@ void main() {
 
           expect(
             headers.acceptLanguage?.languages
-                ?.map((final e) => e.quality)
+                .map((final e) => e.quality)
                 .toList(),
             equals([1.0]),
           );
@@ -171,7 +171,7 @@ void main() {
 
           expect(
             headers.acceptLanguage?.languages
-                ?.map((final e) => e.language)
+                .map((final e) => e.language)
                 .toList(),
             equals(['en']),
           );
@@ -217,13 +217,13 @@ void main() {
 
           expect(
             headers.acceptLanguage?.languages
-                ?.map((final e) => e.language)
+                .map((final e) => e.language)
                 .toList(),
             equals(['*']),
           );
           expect(
             headers.acceptLanguage?.languages
-                ?.map((final e) => e.quality)
+                .map((final e) => e.quality)
                 .toList(),
             equals([0.5]),
           );
@@ -242,7 +242,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.language)
+                  .map((final e) => e.language)
                   .toList(),
               equals(['en', 'fr', 'de']),
             );
@@ -260,7 +260,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.quality)
+                  .map((final e) => e.quality)
                   .toList(),
               equals([1.0, 1.0, 1.0]),
             );
@@ -278,7 +278,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.language)
+                  .map((final e) => e.language)
                   .toList(),
               equals(['en', 'fr', 'de']),
             );
@@ -296,7 +296,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.quality)
+                  .map((final e) => e.quality)
                   .toList(),
               equals([1.0, 0.5, 0.8]),
             );
@@ -314,7 +314,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.language)
+                  .map((final e) => e.language)
                   .toList(),
               equals(['en', 'fr', 'de']),
             );
@@ -332,7 +332,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.quality)
+                  .map((final e) => e.quality)
                   .toList(),
               equals([1.0, 1.0, 1.0]),
             );
@@ -350,7 +350,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.language)
+                  .map((final e) => e.language)
                   .toList(),
               equals(['en', 'fr', 'de']),
             );
@@ -368,7 +368,7 @@ void main() {
 
             expect(
               headers.acceptLanguage?.languages
-                  ?.map((final e) => e.quality)
+                  .map((final e) => e.quality)
                   .toList(),
               equals([1.0, 1.0, 1.0]),
             );

--- a/test/headers/typed/accept_language_test.dart
+++ b/test/headers/typed/accept_language_test.dart
@@ -201,7 +201,7 @@ void main() {
           );
 
           expect(headers.acceptLanguage?.isWildcard, isTrue);
-          expect(headers.acceptLanguage?.languages, isNull);
+          expect(headers.acceptLanguage?.languages, isEmpty);
         },
       );
 

--- a/test/headers/typed/access_control_expose_headers_header_test.dart
+++ b/test/headers/typed/access_control_expose_headers_header_test.dart
@@ -105,7 +105,7 @@ void main() {
         );
 
         expect(headers.accessControlExposeHeaders?.isWildcard, isTrue);
-        expect(headers.accessControlExposeHeaders?.headers, isNull);
+        expect(headers.accessControlExposeHeaders?.headers, isEmpty);
       },
     );
 

--- a/test/headers/typed/forwarded_header_behavior_test.dart
+++ b/test/headers/typed/forwarded_header_behavior_test.dart
@@ -39,16 +39,5 @@ void main() {
 
       expect(header1 == header2, isFalse);
     });
-
-    test(
-        'Given two empty ForwardedHeader instances (one via .empty(), one via empty list), '
-        'when compared with ==, '
-        'then they should be equal and have the same hashCode.', () {
-      final header1 = ForwardedHeader.empty();
-      final header2 = ForwardedHeader([]);
-
-      expect(header1 == header2, isTrue);
-      expect(header1.hashCode, equals(header2.hashCode));
-    });
   });
 }

--- a/test/headers/typed/forwarded_header_test.dart
+++ b/test/headers/typed/forwarded_header_test.dart
@@ -364,17 +364,6 @@ void main() {
 
       expect(encoded, equals([expectedString]));
     });
-
-    test(
-        'Given an empty ForwardedHeader, '
-        'when toStrings() is called, '
-        'then an empty iterable is returned.', () {
-      final header = ForwardedHeader.empty();
-
-      final encoded = header.toStrings();
-
-      expect(encoded, isEmpty);
-    });
   });
 
   group('ForwardedNode Parsing Logic', () {

--- a/test/headers/typed/permissions_policy_header_test.dart
+++ b/test/headers/typed/permissions_policy_header_test.dart
@@ -64,7 +64,7 @@ void main() {
         expect(policies?[0].name, equals('geolocation'));
         expect(policies?[0].values, equals(['self']));
         expect(policies?[1].name, equals('microphone'));
-        expect(policies?[1].values, equals(['']));
+        expect(policies?[1].values, isEmpty);
       },
     );
 

--- a/test/headers/typed/vary_header_test.dart
+++ b/test/headers/typed/vary_header_test.dart
@@ -114,7 +114,7 @@ void main() {
         );
 
         expect(headers.vary?.isWildcard, isTrue);
-        expect(headers.vary?.fields, isNull);
+        expect(headers.vary?.fields, isEmpty);
       },
     );
 

--- a/test/static/range_edge_cases_test.dart
+++ b/test/static/range_edge_cases_test.dart
@@ -254,17 +254,12 @@ void main() {
     test(
         'Given a Range header with no ranges, '
         'when a request is made for the file, '
-        'then a 200 OK status is returned with full content', () async {
-      final headers =
-          Headers.build((final mh) => mh.range = RangeHeader(ranges: []));
-
-      final response =
-          await makeRequest(handler, '/test_file.txt', headers: headers);
-
-      expect(response.statusCode, HttpStatus.ok);
-      expect(response.body.contentLength, fileContent.length);
-      expect(response.readAsString(), completion(fileContent));
-      expect(response.headers.contentRange, isNull);
+        'then an InvalidHeaderException is thrown', () async {
+      final headers = Headers.build((final mh) => mh['Range'] = ['bytes=']);
+      await expectLater(
+        makeRequest(handler, '/test_file.txt', headers: headers),
+        throwsA(isA<InvalidHeaderException>()),
+      );
     });
   });
 }

--- a/test/static/range_edge_cases_test.dart
+++ b/test/static/range_edge_cases_test.dart
@@ -256,7 +256,7 @@ void main() {
         'when a request is made for the file, '
         'then a 200 OK status is returned with full content', () async {
       final headers =
-          Headers.build((final mh) => mh.range = const RangeHeader(ranges: []));
+          Headers.build((final mh) => mh.range = RangeHeader(ranges: []));
 
       final response =
           await makeRequest(handler, '/test_file.txt', headers: headers);


### PR DESCRIPTION
## Description

This improves the usability of HTTP header objects by making them properly comparable and suitable for use in collections. The implementation follows Dart best practices for equality and hash code implementation, ensuring consistent behavior across all header types.

### Technical Details:

- All header classes now implement proper `==` operators that compare all relevant fields
- Hash codes are computed using `Object.hash()` or `Object.hashAll()` for multiple fields
- Collection fields use `ListEquality` or `IterableEquality` for deep comparison

## Related Issues
Fixes: #143
Fixes: #144
Fixed: #145  

## Pre-Launch Checklist

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes

Some constructor are no longer `const` to prevent constructing invalid instances.
