### PR TITLE
chore: Update the copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
-Copyright 2014, the Dart project authors.
-Copyright 2015, the Dart project authors. 
-Copyright 2024, the Serverpod project authors.
+Copyright 2014-2024, the Dart project authors.
+Copyright 2024-2025, the Serverpod project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
## Description
Update the copyright year to span 2025. Attribute Dart project authors up until 2024.

Relic is a fork of [shelf](https://github.com/dart-lang/shelf).
However for reasons that are not clear in hindsight, it didn't start as a proper git fork.

Instead it started as new repo (commit 36b87cc4), and all the existing shelf code was copied in
(in commit 76562673).

However there where already changes done, files moved, etc. And - importantly for this commit -
all the copyright notices were removed from the top of the files, except for the LICENSE file.

This is still the case today, but at least this commit attribute copyright up until 2024 to the
Dart project authors.

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [ ] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [ ] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.