### PR TITLE
refactor: Introduce WildcardListHeader<T> base-class

### DIFF
--- a/lib/src/headers/typed/headers/accept_language_header.dart
+++ b/lib/src/headers/typed/headers/accept_language_header.dart
@@ -1,89 +1,45 @@
-import 'package:collection/collection.dart';
-
 import '../../../../relic.dart';
-import '../../extension/string_list_extensions.dart';
+import 'wildcard_list_header.dart';
 
 /// A class representing the HTTP Accept-Language header.
 ///
 /// This header specifies the natural languages that are preferred in the response.
-final class AcceptLanguageHeader {
-  static const codec = HeaderCodec(AcceptLanguageHeader.parse, __encode);
-  static List<String> __encode(final AcceptLanguageHeader value) =>
-      [value._encode()];
+final class AcceptLanguageHeader extends WildcardListHeader<LanguageQuality> {
+  static const codec = HeaderCodec(_parse, _encode);
 
-  /// The list of languages that are accepted.
-  final List<LanguageQuality> languages;
-
-  /// A boolean value indicating whether the Accept-Language header is a wildcard.
-  final bool isWildcard;
-
-  /// Constructs an instance of [AcceptLanguageHeader] with the given languages.
+  /// Constructs an instance with the given languages
   AcceptLanguageHeader.languages(
       {required final List<LanguageQuality> languages})
-      : assert(languages.isNotEmpty),
-        languages = List.unmodifiable(languages),
-        isWildcard = false;
+      : super(languages);
 
-  /// Constructs an instance of [AcceptLanguageHeader] with a wildcard language.
-  const AcceptLanguageHeader.wildcard()
-      : languages = const [],
-        isWildcard = true;
+  /// Constructs an instance with a wildcard language
+  const AcceptLanguageHeader.wildcard() : super.wildcard();
 
-  /// Parses the Accept-Language header value and returns an [AcceptLanguageHeader] instance.
+  /// Parses the Accept-Language header value and returns an [AcceptLanguageHeader] instance
   factory AcceptLanguageHeader.parse(final Iterable<String> values) {
-    final splitValues = values.splitTrimAndFilterUnique();
-
-    if (splitValues.isEmpty) {
-      throw const FormatException('Value cannot be empty');
-    }
-
-    if (splitValues.length == 1 && splitValues.first == '*') {
-      return const AcceptLanguageHeader.wildcard();
-    }
-
-    if (splitValues.length > 1 && splitValues.contains('*')) {
-      throw const FormatException(
-          'Wildcard (*) cannot be used with other values');
-    }
-
-    final languages = splitValues.map((final value) {
-      final languageParts = value.split(';q=');
-      final language = languageParts[0].trim().toLowerCase();
-      if (language.isEmpty) {
-        throw const FormatException('Invalid language');
-      }
-      double? quality;
-      if (languageParts.length > 1) {
-        final value = double.tryParse(languageParts[1].trim());
-        if (value == null || value < 0 || value > 1) {
-          throw const FormatException('Invalid quality value');
-        }
-        quality = value;
-      }
-      return LanguageQuality(language, quality);
-    }).toList();
-
-    return AcceptLanguageHeader.languages(languages: languages);
+    return _parse(values);
   }
 
-  /// Converts the [AcceptLanguageHeader] instance into a string representation suitable for HTTP headers.
-  String _encode() =>
-      isWildcard ? '*' : languages.map((final e) => e._encode()).join(', ');
+  /// The list of languages that are accepted
+  List<LanguageQuality> get languages => values;
 
-  @override
-  bool operator ==(final Object other) =>
-      identical(this, other) ||
-      other is AcceptLanguageHeader &&
-          isWildcard == other.isWildcard &&
-          const ListEquality<LanguageQuality>()
-              .equals(languages, other.languages);
+  static AcceptLanguageHeader _parse(final Iterable<String> values) {
+    final parsed = WildcardListHeader.parse(values, LanguageQuality.parse);
 
-  @override
-  int get hashCode => Object.hash(
-      isWildcard, const ListEquality<LanguageQuality>().hash(languages));
+    if (parsed.isWildcard) {
+      return const AcceptLanguageHeader.wildcard();
+    } else {
+      return AcceptLanguageHeader.languages(languages: parsed.values);
+    }
+  }
 
-  @override
-  String toString() => 'AcceptLanguageHeader(languages: $languages)';
+  static List<String> encodeHeader(final AcceptLanguageHeader header) {
+    return header.encode((final LanguageQuality lq) => lq.encode()).toList();
+  }
+
+  static List<String> _encode(final AcceptLanguageHeader header) {
+    return encodeHeader(header);
+  }
 }
 
 /// A class representing a language with an optional quality value.
@@ -98,8 +54,30 @@ class LanguageQuality {
   const LanguageQuality(this.language, [final double? quality])
       : quality = quality ?? 1.0;
 
-  /// Converts the [LanguageQuality] instance into a string representation suitable for HTTP headers.
-  String _encode() => quality == 1.0 ? language : '$language;q=$quality';
+  /// Parses a string value and returns a [LanguageQuality] instance.
+  factory LanguageQuality.parse(final String value) {
+    final languageParts = value.split(';q=');
+    final language = languageParts[0].trim().toLowerCase();
+    if (language.isEmpty) {
+      throw const FormatException('Invalid language');
+    }
+
+    double? quality;
+    if (languageParts.length > 1) {
+      final qualityValue = double.tryParse(languageParts[1].trim());
+      if (qualityValue == null || qualityValue < 0 || qualityValue > 1) {
+        throw const FormatException('Invalid quality value');
+      }
+      quality = qualityValue;
+    }
+
+    return LanguageQuality(language, quality);
+  }
+
+  /// Encodes this [LanguageQuality] into a string representation suitable for HTTP headers.
+  String encode() {
+    return quality == 1.0 ? language : '$language;q=$quality';
+  }
 
   @override
   bool operator ==(final Object other) =>

--- a/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
@@ -1,79 +1,47 @@
-import 'package:collection/collection.dart';
-
 import '../../../../relic.dart';
-import '../../extension/string_list_extensions.dart';
+import 'wildcard_list_header.dart';
 
 /// A class representing the HTTP Access-Control-Allow-Methods header.
 ///
 /// This header specifies which methods are allowed when accessing the resource
 /// in response to a preflight request.
-final class AccessControlAllowMethodsHeader {
-  static const codec =
-      HeaderCodec(AccessControlAllowMethodsHeader.parse, __encode);
-  static List<String> __encode(final AccessControlAllowMethodsHeader value) =>
-      [value._encode()];
-
-  /// The list of methods that are allowed.
-  final List<RequestMethod> methods;
-
-  /// Whether all methods are allowed (`*`).
-  final bool isWildcard;
+final class AccessControlAllowMethodsHeader
+    extends WildcardListHeader<RequestMethod> {
+  static const codec = HeaderCodec(_parse, _encode);
 
   /// Constructs an instance allowing specific methods to be allowed.
   AccessControlAllowMethodsHeader.methods(
       {required final List<RequestMethod> methods})
-      : assert(methods.isNotEmpty),
-        methods = List.unmodifiable(methods),
-        isWildcard = false;
+      : super(methods);
 
   /// Constructs an instance allowing all methods to be allowed (`*`).
-  const AccessControlAllowMethodsHeader.wildcard()
-      : methods = const [],
-        isWildcard = true;
+  const AccessControlAllowMethodsHeader.wildcard() : super.wildcard();
 
   /// Parses the Access-Control-Allow-Methods header value and returns an
   /// [AccessControlAllowMethodsHeader] instance.
   factory AccessControlAllowMethodsHeader.parse(final Iterable<String> values) {
-    final splitValues = values.splitTrimAndFilterUnique();
-    if (splitValues.isEmpty) {
-      throw const FormatException(
-        'Value cannot be empty',
-      );
-    }
-
-    if (splitValues.length == 1 && splitValues.first == '*') {
-      return const AccessControlAllowMethodsHeader.wildcard();
-    }
-
-    if (splitValues.length > 1 && splitValues.contains('*')) {
-      throw const FormatException(
-        'Wildcard (*) cannot be used with other values',
-      );
-    }
-
-    return AccessControlAllowMethodsHeader.methods(
-      methods: splitValues.map(RequestMethod.parse).toList(),
-    );
+    return _parse(values);
   }
 
-  /// Converts the [AccessControlAllowMethodsHeader] instance into a string
-  /// representation suitable for HTTP headers.
+  /// The list of methods that are allowed
+  List<RequestMethod> get methods => values;
 
-  String _encode() =>
-      isWildcard ? '*' : methods.map((final m) => m.value).join(', ');
+  static AccessControlAllowMethodsHeader _parse(final Iterable<String> values) {
+    final parsed = WildcardListHeader.parse(values, RequestMethod.parse);
 
-  @override
-  bool operator ==(final Object other) =>
-      identical(this, other) ||
-      other is AccessControlAllowMethodsHeader &&
-          isWildcard == other.isWildcard &&
-          const ListEquality<RequestMethod>().equals(methods, other.methods);
+    if (parsed.isWildcard) {
+      return const AccessControlAllowMethodsHeader.wildcard();
+    } else {
+      return AccessControlAllowMethodsHeader.methods(methods: parsed.values);
+    }
+  }
 
-  @override
-  int get hashCode => Object.hash(
-      isWildcard, const ListEquality<RequestMethod>().hash(methods));
+  static List<String> encodeHeader(
+      final AccessControlAllowMethodsHeader header) {
+    return header.encode((final RequestMethod rm) => rm.value).toList();
+  }
 
-  @override
-  String toString() =>
-      'AccessControlAllowMethodsHeader(methods: $methods, isWildcard: $isWildcard)';
+  static List<String> _encode(final AccessControlAllowMethodsHeader header) {
+    return encodeHeader(header);
+  }
 }

--- a/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
+++ b/lib/src/headers/typed/headers/access_control_allow_methods_header.dart
@@ -60,7 +60,7 @@ final class AccessControlAllowMethodsHeader {
   /// representation suitable for HTTP headers.
 
   String _encode() =>
-      isWildcard ? '*' : methods.map((final m) => m.name).join(', ');
+      isWildcard ? '*' : methods.map((final m) => m.value).join(', ');
 
   @override
   bool operator ==(final Object other) =>

--- a/lib/src/headers/typed/headers/access_control_expose_headers_header.dart
+++ b/lib/src/headers/typed/headers/access_control_expose_headers_header.dart
@@ -1,76 +1,50 @@
-import 'package:collection/collection.dart';
-
 import '../../../../relic.dart';
-import '../../extension/string_list_extensions.dart';
+import 'wildcard_list_header.dart';
 
 /// A class representing the HTTP Access-Control-Expose-Headers header.
 ///
 /// This header specifies which headers can be exposed as part of the response
 /// by listing them explicitly or using a wildcard (`*`) to expose all headers.
-final class AccessControlExposeHeadersHeader {
-  static const codec =
-      HeaderCodec(AccessControlExposeHeadersHeader.parse, __encode);
-  static List<String> __encode(final AccessControlExposeHeadersHeader value) =>
-      [value._encode()];
-
-  /// The list of headers that can be exposed.
-  final List<String> headers;
-
-  /// Whether all headers are allowed to be exposed (`*`).
-  final bool isWildcard;
+final class AccessControlExposeHeadersHeader
+    extends WildcardListHeader<String> {
+  static const codec = HeaderCodec(_parse, _encode);
 
   /// Constructs an instance allowing specific headers to be exposed.
   AccessControlExposeHeadersHeader.headers(
       {required final Iterable<String> headers})
-      : assert(headers.isNotEmpty),
-        headers = List.unmodifiable(headers),
-        isWildcard = false;
+      : super(List.from(headers));
 
   /// Constructs an instance allowing all headers to be exposed (`*`).
-  const AccessControlExposeHeadersHeader.wildcard()
-      : headers = const [],
-        isWildcard = true;
+  const AccessControlExposeHeadersHeader.wildcard() : super.wildcard();
 
   /// Parses the Access-Control-Expose-Headers header value and returns an
   /// [AccessControlExposeHeadersHeader] instance.
   factory AccessControlExposeHeadersHeader.parse(
       final Iterable<String> values) {
-    final splitValues = values.splitTrimAndFilterUnique();
-    if (splitValues.isEmpty) {
-      throw const FormatException('Value cannot be empty');
-    }
-
-    if (splitValues.length == 1 && splitValues.first == '*') {
-      return const AccessControlExposeHeadersHeader.wildcard();
-    }
-
-    if (splitValues.length > 1 && splitValues.contains('*')) {
-      throw const FormatException(
-          'Wildcard (*) cannot be used with other values');
-    }
-
-    return AccessControlExposeHeadersHeader.headers(
-      headers: splitValues,
-    );
+    return _parse(values);
   }
 
-  /// Converts the [AccessControlExposeHeadersHeader] instance into a string
-  /// representation suitable for HTTP headers.
+  /// The list of headers that can be exposed
+  List<String> get headers => values;
 
-  String _encode() => isWildcard ? '*' : headers.join(', ');
+  static AccessControlExposeHeadersHeader _parse(
+      final Iterable<String> values) {
+    final parsed =
+        WildcardListHeader.parse(values, (final String value) => value);
 
-  @override
-  bool operator ==(final Object other) =>
-      identical(this, other) ||
-      other is AccessControlExposeHeadersHeader &&
-          isWildcard == other.isWildcard &&
-          const ListEquality<String>().equals(headers, other.headers);
+    if (parsed.isWildcard) {
+      return const AccessControlExposeHeadersHeader.wildcard();
+    } else {
+      return AccessControlExposeHeadersHeader.headers(headers: parsed.values);
+    }
+  }
 
-  @override
-  int get hashCode =>
-      Object.hash(isWildcard, const ListEquality<String>().hash(headers));
+  static List<String> encodeHeader(
+      final AccessControlExposeHeadersHeader header) {
+    return header.encode((final String str) => str).toList();
+  }
 
-  @override
-  String toString() =>
-      'AccessControlExposeHeadersHeader(headers: $headers, isWildcard: $isWildcard)';
+  static List<String> _encode(final AccessControlExposeHeadersHeader header) {
+    return encodeHeader(header);
+  }
 }

--- a/lib/src/headers/typed/headers/clear_site_data_header.dart
+++ b/lib/src/headers/typed/headers/clear_site_data_header.dart
@@ -51,7 +51,7 @@ final class ClearSiteDataHeader extends WildcardListHeader<ClearSiteDataType> {
 
   static List<String> encodeHeader(final ClearSiteDataHeader header) {
     if (header.isWildcard) {
-      return ['*'];
+      return ['"*"'];
     } else {
       return [
         header.dataTypes

--- a/lib/src/headers/typed/headers/etag_condition_header.dart
+++ b/lib/src/headers/typed/headers/etag_condition_header.dart
@@ -1,134 +1,93 @@
-import 'package:collection/collection.dart';
-
 import '../../../../relic.dart';
-import '../../extension/string_list_extensions.dart';
 import 'etag_header.dart' show InternalEx;
+import 'wildcard_list_header.dart';
 
 /// Base class for ETag-based conditional headers (If-Match and If-None-Match).
-sealed class ETagConditionHeader {
-  /// The list of ETags to match against.
-  final List<ETagHeader> etags;
-
-  /// Whether this is a wildcard match (*).
-  final bool isWildcard;
-
+sealed class ETagConditionHeader extends WildcardListHeader<ETagHeader> {
   /// Creates an [ETagConditionHeader] with specific ETags.
-  const ETagConditionHeader.etags(this.etags) : isWildcard = false;
+  ETagConditionHeader.etags(super.etags);
 
   /// Creates an [ETagConditionHeader] with wildcard matching.
-  const ETagConditionHeader.wildcard()
-      : etags = const [],
-        isWildcard = true;
+  const ETagConditionHeader.wildcard() : super.wildcard();
 
-  /// Converts the header instance to its string representation.
-  String _encode() {
-    if (isWildcard) return '*';
-    return etags.map((final e) => e.encode()).join(', ');
-  }
+  /// The list of ETags to match against
+  List<ETagHeader> get etags => values;
 }
 
 /// A class representing the HTTP If-Match header.
 final class IfMatchHeader extends ETagConditionHeader {
-  static const codec = HeaderCodec(IfMatchHeader.parse, __encode);
-  static List<String> __encode(final IfMatchHeader value) => [value._encode()];
+  static const codec = HeaderCodec(_parse, _encode);
 
   /// Creates an [IfMatchHeader] with specific ETags.
-  const IfMatchHeader.etags(super.etags) : super.etags();
+  IfMatchHeader.etags(super.etags) : super.etags();
 
   /// Creates an [IfMatchHeader] with wildcard matching.
   const IfMatchHeader.wildcard() : super.wildcard();
 
   /// Parses the If-Match header value.
   factory IfMatchHeader.parse(final Iterable<String> values) {
-    final splitValues = values.splitTrimAndFilterUnique();
-    if (splitValues.isEmpty) {
-      throw const FormatException('Value cannot be empty');
-    }
+    return _parse(values);
+  }
 
-    if (splitValues.length == 1 && splitValues.first == '*') {
-      return const IfMatchHeader.wildcard();
-    }
-
-    if (splitValues.length > 1 && splitValues.contains('*')) {
-      throw const FormatException(
-          'Wildcard (*) cannot be used with other values');
-    }
-
-    final parsedEtags = splitValues.map((final value) {
+  static IfMatchHeader _parse(final Iterable<String> values) {
+    final parsed = WildcardListHeader.parse(values, (final String value) {
       if (!ETagHeader.isValidETag(value)) {
         throw const FormatException('Invalid ETag format');
       }
       return ETagHeader.parse(value);
-    }).toList();
+    });
 
-    return IfMatchHeader.etags(parsedEtags);
+    if (parsed.isWildcard) {
+      return const IfMatchHeader.wildcard();
+    } else {
+      return IfMatchHeader.etags(parsed.values);
+    }
   }
 
-  @override
-  bool operator ==(final Object other) =>
-      identical(this, other) ||
-      other is IfMatchHeader &&
-          isWildcard == other.isWildcard &&
-          const ListEquality<ETagHeader>().equals(etags, other.etags);
+  static List<String> encodeHeader(final IfMatchHeader header) {
+    return header.encode((final ETagHeader etag) => etag.encode()).toList();
+  }
 
-  @override
-  int get hashCode =>
-      Object.hash(isWildcard, const ListEquality<ETagHeader>().hash(etags));
-
-  @override
-  String toString() => 'IfMatchHeader(etags: $etags, isWildcard: $isWildcard)';
+  static List<String> _encode(final IfMatchHeader header) {
+    return encodeHeader(header);
+  }
 }
 
 /// A class representing the HTTP If-None-Match header.
 final class IfNoneMatchHeader extends ETagConditionHeader {
-  static const codec = HeaderCodec(IfNoneMatchHeader.parse, __encode);
-  static List<String> __encode(final IfNoneMatchHeader value) =>
-      [value._encode()];
+  static const codec = HeaderCodec(_parse, _encode);
 
   /// Creates an [IfNoneMatchHeader] with specific ETags.
-  const IfNoneMatchHeader.etags(super.etags) : super.etags();
+  IfNoneMatchHeader.etags(super.etags) : super.etags();
 
   /// Creates an [IfNoneMatchHeader] with wildcard matching.
   const IfNoneMatchHeader.wildcard() : super.wildcard();
 
   /// Parses the If-None-Match header value.
   factory IfNoneMatchHeader.parse(final Iterable<String> values) {
-    final splitValues = values.splitTrimAndFilterUnique();
-    if (splitValues.isEmpty) {
-      throw const FormatException('Value cannot be empty');
-    }
+    return _parse(values);
+  }
 
-    if (splitValues.length == 1 && splitValues.first == '*') {
-      return const IfNoneMatchHeader.wildcard();
-    }
-
-    if (splitValues.length > 1 && splitValues.contains('*')) {
-      throw const FormatException(
-          'Wildcard (*) cannot be used with other values');
-    }
-
-    final parsedEtags = splitValues.map((final value) {
+  static IfNoneMatchHeader _parse(final Iterable<String> values) {
+    final parsed = WildcardListHeader.parse(values, (final String value) {
       if (!ETagHeader.isValidETag(value)) {
         throw const FormatException('Invalid ETag format');
       }
       return ETagHeader.parse(value);
-    }).toList();
+    });
 
-    return IfNoneMatchHeader.etags(parsedEtags);
+    if (parsed.isWildcard) {
+      return const IfNoneMatchHeader.wildcard();
+    } else {
+      return IfNoneMatchHeader.etags(parsed.values);
+    }
   }
 
-  @override
-  bool operator ==(final Object other) =>
-      identical(this, other) ||
-      other is IfNoneMatchHeader &&
-          isWildcard == other.isWildcard &&
-          const ListEquality<ETagHeader>().equals(etags, other.etags);
+  static List<String> encodeHeader(final IfNoneMatchHeader header) {
+    return header.encode((final ETagHeader etag) => etag.encode()).toList();
+  }
 
-  @override
-  int get hashCode =>
-      Object.hash(isWildcard, const ListEquality<ETagHeader>().hash(etags));
-
-  @override
-  String toString() =>
-      'IfNoneMatchHeader(etags: $etags, isWildcard: $isWildcard)';
+  static List<String> _encode(final IfNoneMatchHeader header) {
+    return encodeHeader(header);
+  }
 }

--- a/lib/src/headers/typed/headers/wildcard_list_header.dart
+++ b/lib/src/headers/typed/headers/wildcard_list_header.dart
@@ -1,0 +1,83 @@
+import '../../extension/string_list_extensions.dart';
+
+/// A generic class representing HTTP headers that accept a list of values with optional wildcards.
+///
+/// This base class handles the common pattern where a header can either:
+/// - Accept a wildcard "*" meaning "accept all"
+/// - Accept a list of specific typed values
+///
+/// The wildcard and list values are mutually exclusive - if wildcard is true,
+/// the values list will be empty, and vice versa.
+class WildcardListHeader<T> {
+  /// The list of values that are accepted
+  final List<T> values;
+
+  /// A boolean value indicating whether the header is a wildcard
+  final bool isWildcard;
+
+  /// Constructs an instance with the given values
+  WildcardListHeader(final List<T> values)
+      : assert(values.isNotEmpty, 'Values list cannot be empty'),
+        values = List.unmodifiable(values),
+        isWildcard = false;
+
+  /// Constructs an instance with a wildcard
+  const WildcardListHeader.wildcard()
+      : values = const [],
+        isWildcard = true;
+
+  /// Parses header values and returns a WildcardListHeader instance
+  factory WildcardListHeader.parse(
+    final Iterable<String> headerValues,
+    final T Function(String) parseElement,
+  ) {
+    final splitValues = headerValues.splitTrimAndFilterUnique();
+
+    if (splitValues.isEmpty) {
+      throw const FormatException('Value cannot be empty');
+    }
+
+    if (splitValues.length == 1 && splitValues.first == '*') {
+      return const WildcardListHeader.wildcard();
+    }
+
+    if (splitValues.length > 1 && splitValues.contains('*')) {
+      throw const FormatException(
+          'Wildcard (*) cannot be used with other values');
+    }
+
+    final parsedValues = splitValues.map(parseElement).toList();
+    return WildcardListHeader(parsedValues);
+  }
+
+  /// Converts the header instance into a string representation suitable for HTTP headers
+  Iterable<String> encode(final String Function(T) encodeElement) {
+    if (isWildcard) {
+      return ['*'];
+    } else {
+      return [values.map(encodeElement).join(', ')];
+    }
+  }
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is WildcardListHeader<T> &&
+          isWildcard == other.isWildcard &&
+          _listEquals(values, other.values);
+
+  @override
+  int get hashCode => Object.hash(isWildcard, Object.hashAll(values));
+
+  @override
+  String toString() =>
+      'WildcardListHeader(values: $values, isWildcard: $isWildcard)';
+
+  static bool _listEquals<T>(final List<T> a, final List<T> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/lib/src/headers/typed/headers/wildcard_list_header.dart
+++ b/lib/src/headers/typed/headers/wildcard_list_header.dart
@@ -16,9 +16,14 @@ class WildcardListHeader<T> {
   bool get isWildcard => values.isEmpty;
 
   /// Constructs an instance with the given values
+  ///
+  /// Passing an empty list will raise an ArgumentError
   WildcardListHeader(final List<T> values)
-      : assert(values.isNotEmpty, 'Values list cannot be empty'),
-        values = List.unmodifiable(values);
+      : values = List.unmodifiable(values) {
+    if (values.isEmpty) {
+      throw ArgumentError.value(values, 'values', 'Cannot be empty');
+    }
+  }
 
   /// Constructs an instance with a wildcard
   const WildcardListHeader.wildcard() : values = const [];
@@ -59,9 +64,7 @@ class WildcardListHeader<T> {
   @override
   bool operator ==(final Object other) =>
       identical(this, other) ||
-      other is WildcardListHeader<T> &&
-          isWildcard == other.isWildcard &&
-          _listEquals(values, other.values);
+      other is WildcardListHeader<T> && _listEquals(values, other.values);
 
   @override
   int get hashCode => Object.hash(isWildcard, Object.hashAll(values));

--- a/lib/src/headers/typed/headers/wildcard_list_header.dart
+++ b/lib/src/headers/typed/headers/wildcard_list_header.dart
@@ -13,18 +13,15 @@ class WildcardListHeader<T> {
   final List<T> values;
 
   /// A boolean value indicating whether the header is a wildcard
-  final bool isWildcard;
+  bool get isWildcard => values.isEmpty;
 
   /// Constructs an instance with the given values
   WildcardListHeader(final List<T> values)
       : assert(values.isNotEmpty, 'Values list cannot be empty'),
-        values = List.unmodifiable(values),
-        isWildcard = false;
+        values = List.unmodifiable(values);
 
   /// Constructs an instance with a wildcard
-  const WildcardListHeader.wildcard()
-      : values = const [],
-        isWildcard = true;
+  const WildcardListHeader.wildcard() : values = const [];
 
   /// Parses header values and returns a WildcardListHeader instance
   factory WildcardListHeader.parse(

--- a/test/headers/header_test.dart
+++ b/test/headers/header_test.dart
@@ -695,7 +695,7 @@ void main() {
       (
         Headers.ifMatch,
         (final h) =>
-            h.ifMatch = const IfMatchHeader.etags([ETagHeader(value: 'foobar')])
+            h.ifMatch = IfMatchHeader.etags([const ETagHeader(value: 'foobar')])
       ),
       (
         Headers.ifModifiedSince,

--- a/test/headers/typed/access_control_allow_headers_header_test.dart
+++ b/test/headers/typed/access_control_allow_headers_header_test.dart
@@ -52,7 +52,7 @@ void main() {
           throwsA(isA<BadRequestException>().having(
             (final e) => e.message,
             'message',
-            contains('Wildcard (*) cannot be used with other headers'),
+            contains('Wildcard (*) cannot be used with other values'),
           )),
         );
       },

--- a/test/static/if_none_match_test.dart
+++ b/test/static/if_none_match_test.dart
@@ -39,8 +39,8 @@ void main() {
       'when a request is made for the file, '
       'then a 200 OK status is returned with the full body', () async {
     const nonMatchingEtag = ETagHeader(value: 'non-existent-etag');
-    final headers = Headers.build(
-        (final mh) => mh.ifNoneMatch = const IfNoneMatchHeader.etags(
+    final headers =
+        Headers.build((final mh) => mh.ifNoneMatch = IfNoneMatchHeader.etags(
               [nonMatchingEtag],
             ));
 


### PR DESCRIPTION
 ## Description
Refactors HTTP header classes to use a generic `WildcardListHeader<T>` base class. Moves parsing logic to factory constructors and encoding logic to instance methods on quality classes. Unifies the implementation pattern across all wildcard headers including Accept-Encoding, Accept-Language, Access-Control headers, Clear-Site-Data, and ETag condition headers.

## Related Issues
N/A

## Pre-Launch Checklist
- [x] This update focuses on a single feature or bug fix.
- [x] I have read and followed the Dart Style Guide and formatted the code using dart format.
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation, ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [x] Includes breaking changes.

ETagConditionHeader constructors are no longer const due to base class constraints.

## Additional Notes
All wildcard headers now follow consistent inheritance pattern. Test coverage maintained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified wildcard/list handling across multiple headers for consistent parsing and encoding.
  - Added encode helpers and new parse/encode methods for encoding and language quality values.

- Bug Fixes
  - Stricter validation: reject mixing wildcard (*) with other values; improved trimming, deduplication, and q-value checks.
  - More accurate, standardized header encoding.

- Refactor
  - Headers now use a common base with simplified constructors and getters replacing fields.

- Tests
  - Updated expectations and constructor usage to match new behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->