### PR TITLE
fix: Set content length on body, not headers

### DIFF
--- a/lib/src/io/static/static_handler.dart
+++ b/lib/src/io/static/static_handler.dart
@@ -213,7 +213,6 @@ Headers _buildBaseHeaders(
     final _FileInfo fileInfo, final CacheControlHeader? cacheControl) {
   return Headers.build((final mh) => mh
     ..acceptRanges = AcceptRangesHeader.bytes()
-    ..contentLength = fileInfo.stat.size
     ..etag = ETagHeader(value: fileInfo.etag)
     ..lastModified = fileInfo.stat.modified
     ..cacheControl = cacheControl);
@@ -319,8 +318,6 @@ ResponseContext _serveSingleRange(
     return ctx.respond(Response(416, headers: headers));
   }
 
-  final length = end - start;
-
   return ctx.respond(Response(
     HttpStatus.partialContent,
     headers: headers.transform((final mh) => mh
@@ -328,8 +325,7 @@ ResponseContext _serveSingleRange(
         start: start,
         end: end - 1,
         size: fileInfo.stat.size,
-      )
-      ..contentLength = length),
+      )),
     body: _createRangeBody(file, fileInfo, start, end),
   ));
 }
@@ -368,7 +364,6 @@ Future<ResponseContext> _serveMultipleRanges(
   return ctx.respond(Response(
     HttpStatus.partialContent,
     headers: headers.transform((final mh) => mh
-      ..contentLength = totalLength
       ..[Headers.contentTypeHeader] = [
         '${MimeType.multipartByteranges.toHeaderValue()}; boundary=$boundary'
       ]),


### PR DESCRIPTION
## Description
Content-Length is handled by `Body`. Don't set directly on `Headers`.

## Related Issues
Fixes: #138 

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Corrected HTTP headers for static file responses: Content-Length is no longer sent in base responses where size may vary and is omitted for multipart/byteranges replies, improving standards compliance and client compatibility.

- Refactor
  - Internal adjustments to how response headers are built for range and multipart responses.

- Notes
  - No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->