### PR TITLE
fix(server): unset default `x-powered-by` header when null is passed

### DIFF
--- a/lib/src/adapter/io/io_serve.dart
+++ b/lib/src/adapter/io/io_serve.dart
@@ -26,7 +26,7 @@ Future<RelicServer> serve(
   final int? backlog,
   final bool shared = false,
   final bool strictHeaders = false,
-  final String? poweredByHeader,
+  final String? poweredByHeader = RelicServer.defaultPoweredByHeader,
 }) async {
   final adapter = IOAdapter(await bindHttpServer(
     address,

--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -28,14 +28,14 @@ class RelicServer {
   StreamSubscription<AdapterRequest>? _subscription;
 
   /// The powered by header to use for responses.
-  final String poweredByHeader;
+  final String? poweredByHeader;
 
   /// Creates a server with the given parameters.
   RelicServer(
     this.adapter, {
     this.strictHeaders = false,
-    final String? poweredByHeader,
-  }) : poweredByHeader = poweredByHeader ?? defaultPoweredByHeader;
+    this.poweredByHeader = defaultPoweredByHeader,
+  });
 
   /// Mounts a handler to the server and starts listening for requests.
   ///

--- a/test/relic_server_serve_test.dart
+++ b/test/relic_server_serve_test.dart
@@ -391,6 +391,15 @@ void main() {
       final response = await _get();
       expect(response.headers, containsPair(poweredBy, 'myServer'));
     });
+
+    test('can be unset at the server level', () async {
+      _server = await testServe(
+        syncHandler,
+        poweredByHeader: null,
+      );
+      final response = await _get();
+      expect(response.headers[poweredBy], isNull);
+    });
   });
 
   test(

--- a/test/util/test_util.dart
+++ b/test/util/test_util.dart
@@ -59,7 +59,7 @@ final isOhNoStateError =
 Future<RelicServer> testServe(
   final Handler handler, {
   final SecurityContext? context,
-  final String? poweredByHeader,
+  final String? poweredByHeader = RelicServer.defaultPoweredByHeader,
 }) =>
     serve(
       handler,


### PR DESCRIPTION
## Description
When `poweredByHeader` is passed with a null value, avoid setting the default "Relic" value. 

## Related Issues
Fixes #162 

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.
