### PR TITLE
feat!: Custom CacheControl header per file

### DIFF
--- a/lib/src/io/static/static_handler.dart
+++ b/lib/src/io/static/static_handler.dart
@@ -205,7 +205,7 @@ Future<MimeType?> _detectMimeType(
   final headerBytes = await file
       .openRead(0, mimeResolver.magicNumbersMaxLength)
       .cast<Uint8List>()
-      .first;
+      .firstOrNull;
 
   final mimeString = mimeResolver.lookup(file.path, headerBytes: headerBytes);
   return mimeString != null ? MimeType.parse(mimeString) : null;
@@ -444,4 +444,13 @@ Body _createRangeBody(final FileInfo fileInfo, final int start, final int end) {
     mimeType: fileInfo.mimeType,
     encoding: fileInfo.mimeType?.isText == true ? utf8 : null,
   );
+}
+
+extension<T> on Stream<T> {
+  Future<T?> get firstOrNull async {
+    await for (final value in this) {
+      return value;
+    }
+    return null;
+  }
 }

--- a/lib/src/io/static/static_handler.dart
+++ b/lib/src/io/static/static_handler.dart
@@ -39,7 +39,7 @@ final _fileInfoCache = LruCache<String, FileInfo>(10000);
 /// When a file is requested, it is served with appropriate headers including
 /// ETag, Last-Modified, and Cache-Control. The handler supports:
 /// - Conditional requests (If-None-Match, If-Modified-Since, If-Range (for range request))
-/// - Range requests for partial content (multi-range is supported, but ranges are not coalesed)
+/// - Range requests for partial content (multi-range is supported, but ranges are not coalesced)
 /// - Proper MIME type detection (from magic-bytes prefixes, or file extension)
 ///
 /// If the requested path doesn't correspond to a file, the [defaultHandler] is called.
@@ -47,11 +47,11 @@ final _fileInfoCache = LruCache<String, FileInfo>(10000);
 /// Directory listings are not supported for security reasons.
 ///
 /// The handler requires the request method to be either GET, or HEAD.
-/// Otherwise, a 405 Method Not Allowed response is returned witn an
+/// Otherwise, a 405 Method Not Allowed response is returned with an
 /// appropriate Allow header.
 ///
 /// The [mimeResolver] can be provided to customize MIME type detection.
-/// The [cacheControl] header can be customized; defaults to not being set.
+/// The [cacheControl] header can be customized using [cacheControl] callback.
 Handler createStaticHandler(
   final String fileSystemPath, {
   final Handler? defaultHandler,
@@ -101,12 +101,12 @@ Handler createStaticHandler(
 /// The file must exist at the specified path or an [ArgumentError] is thrown.
 /// Supports the same features as [createStaticHandler] but for a single file.
 ///
-/// The handler requires the request method to be either GET, or HEAD.
-/// Otherwise, a 405 Method Not Allowed response is returned witn an
+/// The handler requires the request method to be either GET or HEAD.
+/// Otherwise, a 405 Method Not Allowed response is returned with an
 /// appropriate Allow header.
 ///
 /// The [mimeResolver] can be provided to customize MIME type detection.
-/// The [cacheControl] header can be customized; defaults to no-cache with private cache.
+/// The [cacheControl] header can be customized using [cacheControl] callback.
 Handler createFileHandler(
   final String filePath, {
   final MimeTypeResolver? mimeResolver,

--- a/test/static/alternative_root_test.dart
+++ b/test/static/alternative_root_test.dart
@@ -18,8 +18,8 @@ void main() {
 
   test('Given a root file when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(
       handler,
@@ -34,8 +34,8 @@ void main() {
   test(
       'Given a root file with space when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(
         handler, '/static/files/with%20space.txt',
@@ -48,8 +48,8 @@ void main() {
   test(
       'Given a root file with unencoded space when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(
         handler, '/static/files/with%20space.txt',
@@ -62,8 +62,8 @@ void main() {
   test(
       'Given a file under directory when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/static/files/test.txt',
         handlerPath: 'static');
@@ -74,8 +74,8 @@ void main() {
 
   test('Given a non-existent file when accessed then it returns a 404 status',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/static/not_here.txt',
         handlerPath: 'static');

--- a/test/static/alternative_root_test.dart
+++ b/test/static/alternative_root_test.dart
@@ -18,7 +18,8 @@ void main() {
 
   test('Given a root file when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(
       handler,
@@ -33,7 +34,8 @@ void main() {
   test(
       'Given a root file with space when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(
         handler, '/static/files/with%20space.txt',
@@ -46,7 +48,8 @@ void main() {
   test(
       'Given a root file with unencoded space when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(
         handler, '/static/files/with%20space.txt',
@@ -59,7 +62,8 @@ void main() {
   test(
       'Given a file under directory when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/static/files/test.txt',
         handlerPath: 'static');
@@ -70,7 +74,8 @@ void main() {
 
   test('Given a non-existent file when accessed then it returns a 404 status',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/static/not_here.txt',
         handlerPath: 'static');

--- a/test/static/basic_file_test.dart
+++ b/test/static/basic_file_test.dart
@@ -36,8 +36,8 @@ void main() {
 
   test('Given a root file when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/root.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -48,8 +48,8 @@ void main() {
   test(
       'Given a HEAD request when made then it returns the correct headers without body',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response =
         await makeRequest(handler, '/root.txt', method: RequestMethod.head);
@@ -61,8 +61,8 @@ void main() {
   test(
       'Given a root file with space when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/files/with%20space.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -73,8 +73,8 @@ void main() {
   test(
       'Given a root file with unencoded space when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/files/with space.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -85,8 +85,8 @@ void main() {
   test(
       'Given a file under directory when accessed then it returns the file content',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/files/test.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -96,8 +96,8 @@ void main() {
 
   test('Given a non-existent file when accessed then it returns a 404 status',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/not_here.txt');
     expect(response.statusCode, HttpStatus.notFound);
@@ -106,8 +106,8 @@ void main() {
   test(
       'Given a file when accessed then it returns the correct last modified date',
       () async {
-    final handler =
-        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    final handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
 
     final rootPath = p.join(d.sandbox, 'root.txt');
     final modified = File(rootPath).statSync().modified.toUtc();
@@ -122,8 +122,8 @@ void main() {
   group('Given if modified since', () {
     test('when it is the same as last modified then it returns not modified',
         () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final rootPath = p.join(d.sandbox, 'root.txt');
       final modified = File(rootPath).statSync().modified.toUtc();
@@ -138,8 +138,8 @@ void main() {
     });
 
     test('when it is before last modified then it returns the file', () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final rootPath = p.join(d.sandbox, 'root.txt');
       final modified = File(rootPath).statSync().modified.toUtc();
@@ -161,8 +161,8 @@ void main() {
 
     test('when it is after last modified then it returns not modified',
         () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final rootPath = p.join(d.sandbox, 'root.txt');
       final modified = File(rootPath).statSync().modified.toUtc();
@@ -183,8 +183,8 @@ void main() {
     test(
         'when file is modified after the request then it returns the updated file',
         () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
       final rootPath = p.join(d.sandbox, 'root.txt');
 
       final response1 = await makeRequest(handler, '/root.txt');
@@ -211,8 +211,8 @@ void main() {
 
   group('Given content type', () {
     test('when accessing root.txt then it should be text/plain', () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/root.txt');
       expect(response.mimeType?.primaryType, 'text');
@@ -220,8 +220,8 @@ void main() {
     });
 
     test('when accessing index.html then it should be text/html', () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/index.html');
       expect(response.mimeType?.primaryType, 'text');
@@ -231,8 +231,8 @@ void main() {
     test(
         'when accessing random.unknown, '
         'then it should be application/octet-stream', () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/random.unknown');
       expect(response.mimeType, MimeType.octetStream);
@@ -240,8 +240,8 @@ void main() {
 
     test('when accessing header_bytes_test_image then it should be image/png',
         () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final response =
           await makeRequest(handler, '/files/header_bytes_test_image');
@@ -264,7 +264,7 @@ void main() {
           ],
         );
       final handler = createStaticHandler(
-          cacheControl: (final _) => null,
+          cacheControl: (final _, final __) => null,
           d.sandbox,
           /* useHeaderBytesForContentType: true, */ mimeResolver: resolver);
 

--- a/test/static/basic_file_test.dart
+++ b/test/static/basic_file_test.dart
@@ -36,7 +36,8 @@ void main() {
 
   test('Given a root file when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/root.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -47,7 +48,8 @@ void main() {
   test(
       'Given a HEAD request when made then it returns the correct headers without body',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response =
         await makeRequest(handler, '/root.txt', method: RequestMethod.head);
@@ -59,7 +61,8 @@ void main() {
   test(
       'Given a root file with space when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/files/with%20space.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -70,7 +73,8 @@ void main() {
   test(
       'Given a root file with unencoded space when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/files/with space.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -81,7 +85,8 @@ void main() {
   test(
       'Given a file under directory when accessed then it returns the file content',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/files/test.txt');
     expect(response.statusCode, HttpStatus.ok);
@@ -91,7 +96,8 @@ void main() {
 
   test('Given a non-existent file when accessed then it returns a 404 status',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final response = await makeRequest(handler, '/not_here.txt');
     expect(response.statusCode, HttpStatus.notFound);
@@ -100,7 +106,8 @@ void main() {
   test(
       'Given a file when accessed then it returns the correct last modified date',
       () async {
-    final handler = createStaticHandler(cacheControl: null, d.sandbox);
+    final handler =
+        createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
     final rootPath = p.join(d.sandbox, 'root.txt');
     final modified = File(rootPath).statSync().modified.toUtc();
@@ -115,7 +122,8 @@ void main() {
   group('Given if modified since', () {
     test('when it is the same as last modified then it returns not modified',
         () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final rootPath = p.join(d.sandbox, 'root.txt');
       final modified = File(rootPath).statSync().modified.toUtc();
@@ -130,7 +138,8 @@ void main() {
     });
 
     test('when it is before last modified then it returns the file', () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final rootPath = p.join(d.sandbox, 'root.txt');
       final modified = File(rootPath).statSync().modified.toUtc();
@@ -152,7 +161,8 @@ void main() {
 
     test('when it is after last modified then it returns not modified',
         () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final rootPath = p.join(d.sandbox, 'root.txt');
       final modified = File(rootPath).statSync().modified.toUtc();
@@ -173,7 +183,8 @@ void main() {
     test(
         'when file is modified after the request then it returns the updated file',
         () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
       final rootPath = p.join(d.sandbox, 'root.txt');
 
       final response1 = await makeRequest(handler, '/root.txt');
@@ -200,7 +211,8 @@ void main() {
 
   group('Given content type', () {
     test('when accessing root.txt then it should be text/plain', () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/root.txt');
       expect(response.mimeType?.primaryType, 'text');
@@ -208,7 +220,8 @@ void main() {
     });
 
     test('when accessing index.html then it should be text/html', () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/index.html');
       expect(response.mimeType?.primaryType, 'text');
@@ -218,7 +231,8 @@ void main() {
     test(
         'when accessing random.unknown, '
         'then it should be application/octet-stream', () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/random.unknown');
       expect(response.mimeType, MimeType.octetStream);
@@ -226,7 +240,8 @@ void main() {
 
     test('when accessing header_bytes_test_image then it should be image/png',
         () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final response =
           await makeRequest(handler, '/files/header_bytes_test_image');
@@ -249,7 +264,7 @@ void main() {
           ],
         );
       final handler = createStaticHandler(
-          cacheControl: null,
+          cacheControl: (final _) => null,
           d.sandbox,
           /* useHeaderBytesForContentType: true, */ mimeResolver: resolver);
 

--- a/test/static/cache_control_test.dart
+++ b/test/static/cache_control_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   test(
@@ -27,7 +27,7 @@ void main() {
     );
     handler = createStaticHandler(
       d.sandbox,
-      cacheControl: cacheControl,
+      cacheControl: (final _) => cacheControl,
     );
 
     final response = await makeRequest(handler, '/test_file.txt');

--- a/test/static/cache_control_test.dart
+++ b/test/static/cache_control_test.dart
@@ -8,15 +8,17 @@ import 'test_util.dart'; // Provides the makeRequest helper
 
 void main() {
   const fileContent = '0123456789ABCDEF'; // 16 bytes
-  late Handler handler;
+  final cacheControl = CacheControlHeader(
+    maxAge: 3600,
+    publicCache: true,
+    mustRevalidate: true,
+  );
 
-  setUp(() async {
+  setUpAll(() async {
     await d.dir('', [
       d.file('test_file.txt', fileContent),
       d.file('image.jpg'),
     ]).create();
-    handler = createStaticHandler(
-        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   test(
@@ -24,16 +26,8 @@ void main() {
       'when a file is served, '
       'then the response includes the specified Cache-Control header',
       () async {
-    final cacheControl = CacheControlHeader(
-      maxAge: 3600,
-      publicCache: true,
-      mustRevalidate: true,
-    );
-    handler = createStaticHandler(
-      d.sandbox,
-      cacheControl: (final _, final __) => cacheControl,
-    );
-
+    final handler = createStaticHandler(d.sandbox,
+        cacheControl: (final _, final __) => cacheControl);
     final response = await makeRequest(handler, '/test_file.txt');
 
     expect(response.statusCode, HttpStatus.ok);
@@ -47,36 +41,43 @@ void main() {
       'Given no Cache-Control header is specified on the server, '
       'when a file is served, '
       'then the response includes no Cache-Control header', () async {
+    final handler = createStaticHandler(d.sandbox,
+        cacheControl: (final _, final __) => null);
     final response = await makeRequest(handler, '/test_file.txt');
 
     expect(response.statusCode, HttpStatus.ok);
     expect(response.headers.cacheControl, isNull);
   });
 
-  test(
-      'Given Cache-Control header is set on the server for some files '
-      'when such a file is served, '
-      'then the response includes the specified Cache-Control header '
-      'otherwise not', () async {
-    final cacheControl = CacheControlHeader(
-      maxAge: 3600,
-      publicCache: true,
-      mustRevalidate: true,
-    );
-    handler = createStaticHandler(
-      d.sandbox,
-      cacheControl: (final _, final fileInfo) =>
-          fileInfo.file.path.endsWith('jpg') ? cacheControl : null,
-    );
-    var response = await makeRequest(handler, '/image.jpg');
-    expect(response.statusCode, HttpStatus.ok);
-    expect(response.headers.cacheControl, isNotNull);
-    expect(response.headers.cacheControl!.maxAge, 3600);
-    expect(response.headers.cacheControl!.publicCache, isTrue);
-    expect(response.headers.cacheControl!.mustRevalidate, isTrue);
+  group('Given Cache-Control header is set for a file pattern', () {
+    late Handler handler;
+    setUpAll(() {
+      handler = createStaticHandler(
+        d.sandbox,
+        cacheControl: (final _, final fileInfo) =>
+            fileInfo.file.path.endsWith('jpg') ? cacheControl : null,
+      );
+    });
 
-    response = await makeRequest(handler, '/test_file.txt');
-    expect(response.statusCode, HttpStatus.ok);
-    expect(response.headers.cacheControl, isNull);
+    test(
+        'when a matching file is served, '
+        'then the response includes the specified Cache-Control header',
+        () async {
+      final response = await makeRequest(handler, '/image.jpg');
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.cacheControl, isNotNull);
+      expect(response.headers.cacheControl!.maxAge, 3600);
+      expect(response.headers.cacheControl!.publicCache, isTrue);
+      expect(response.headers.cacheControl!.mustRevalidate, isTrue);
+    });
+
+    test(
+        'when a non-matching file is served, '
+        "then the response doesn't includes the specified Cache-Control header",
+        () async {
+      final response = await makeRequest(handler, '/test_file.txt');
+      expect(response.statusCode, HttpStatus.ok);
+      expect(response.headers.cacheControl, isNull);
+    });
   });
 }

--- a/test/static/cache_control_test.dart
+++ b/test/static/cache_control_test.dart
@@ -11,7 +11,10 @@ void main() {
   late Handler handler;
 
   setUp(() async {
-    await d.file('test_file.txt', fileContent).create();
+    await d.dir('', [
+      d.file('test_file.txt', fileContent),
+      d.file('image.jpg'),
+    ]).create();
     handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
@@ -45,6 +48,33 @@ void main() {
       'then the response includes no Cache-Control header', () async {
     final response = await makeRequest(handler, '/test_file.txt');
 
+    expect(response.statusCode, HttpStatus.ok);
+    expect(response.headers.cacheControl, isNull);
+  });
+
+  test(
+      'Given Cache-Control header is set on the server for some files '
+      'when such a file is served, '
+      'then the response includes the specified Cache-Control header '
+      'otherwise not', () async {
+    final cacheControl = CacheControlHeader(
+      maxAge: 3600,
+      publicCache: true,
+      mustRevalidate: true,
+    );
+    handler = createStaticHandler(
+      d.sandbox,
+      cacheControl: (final fileInfo) =>
+          fileInfo.file.path.endsWith('jpg') ? cacheControl : null,
+    );
+    var response = await makeRequest(handler, '/image.jpg');
+    expect(response.statusCode, HttpStatus.ok);
+    expect(response.headers.cacheControl, isNotNull);
+    expect(response.headers.cacheControl!.maxAge, 3600);
+    expect(response.headers.cacheControl!.publicCache, isTrue);
+    expect(response.headers.cacheControl!.mustRevalidate, isTrue);
+
+    response = await makeRequest(handler, '/test_file.txt');
     expect(response.statusCode, HttpStatus.ok);
     expect(response.headers.cacheControl, isNull);
   });

--- a/test/static/cache_control_test.dart
+++ b/test/static/cache_control_test.dart
@@ -15,7 +15,8 @@ void main() {
       d.file('test_file.txt', fileContent),
       d.file('image.jpg'),
     ]).create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   test(
@@ -30,7 +31,7 @@ void main() {
     );
     handler = createStaticHandler(
       d.sandbox,
-      cacheControl: (final _) => cacheControl,
+      cacheControl: (final _, final __) => cacheControl,
     );
 
     final response = await makeRequest(handler, '/test_file.txt');
@@ -64,7 +65,7 @@ void main() {
     );
     handler = createStaticHandler(
       d.sandbox,
-      cacheControl: (final fileInfo) =>
+      cacheControl: (final _, final fileInfo) =>
           fileInfo.file.path.endsWith('jpg') ? cacheControl : null,
     );
     var response = await makeRequest(handler, '/image.jpg');

--- a/test/static/content_type_test.dart
+++ b/test/static/content_type_test.dart
@@ -26,7 +26,7 @@ void main() {
     await d.file('image.svg', '<svg></svg>').create();
     await d.file('app.wasm', 'fake wasm content').create();
     await d.file('no_extension', 'content without extension').create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   parameterizedTest(
@@ -67,7 +67,9 @@ void main() {
       final customResolver = MimeTypeResolver()
         ..addExtension('txt', 'application/x-my-text');
       handler = createStaticHandler(
-          cacheControl: null, d.sandbox, mimeResolver: customResolver);
+          cacheControl: (final _) => null,
+          d.sandbox,
+          mimeResolver: customResolver);
 
       final response = await makeRequest(handler, '/test.txt');
 
@@ -84,7 +86,9 @@ void main() {
       final customResolver = MimeTypeResolver()
         ..addExtension('custom', 'text/custom');
       handler = createStaticHandler(
-          cacheControl: null, d.sandbox, mimeResolver: customResolver);
+          cacheControl: (final _) => null,
+          d.sandbox,
+          mimeResolver: customResolver);
 
       final response = await makeRequest(handler, '/test.custom');
 

--- a/test/static/content_type_test.dart
+++ b/test/static/content_type_test.dart
@@ -26,7 +26,8 @@ void main() {
     await d.file('image.svg', '<svg></svg>').create();
     await d.file('app.wasm', 'fake wasm content').create();
     await d.file('no_extension', 'content without extension').create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   parameterizedTest(
@@ -67,7 +68,7 @@ void main() {
       final customResolver = MimeTypeResolver()
         ..addExtension('txt', 'application/x-my-text');
       handler = createStaticHandler(
-          cacheControl: (final _) => null,
+          cacheControl: (final _, final __) => null,
           d.sandbox,
           mimeResolver: customResolver);
 
@@ -86,7 +87,7 @@ void main() {
       final customResolver = MimeTypeResolver()
         ..addExtension('custom', 'text/custom');
       handler = createStaticHandler(
-          cacheControl: (final _) => null,
+          cacheControl: (final _, final __) => null,
           d.sandbox,
           mimeResolver: customResolver);
 

--- a/test/static/create_file_handler_test.dart
+++ b/test/static/create_file_handler_test.dart
@@ -15,7 +15,8 @@ void main() {
 
   test('Given a file when served then it returns the file contents', () async {
     final handler = createFileHandler(
-        cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
+        cacheControl: (final _, final __) => null,
+        p.join(d.sandbox, 'file.txt'));
     final response = await makeRequest(handler, '/file.txt');
     expect(response.statusCode, HttpStatus.ok);
     expect(response.body.contentLength, 8);
@@ -28,7 +29,7 @@ void main() {
           ..get(
               '/foo/bar',
               createFileHandler(
-                  cacheControl: (final _) => null,
+                  cacheControl: (final _, final __) => null,
                   p.join(d.sandbox, 'file.txt')))))
         .addHandler(respondWith((final _) => Response.notFound()));
     final response = await makeRequest(handler, '/foo/file.txt');
@@ -43,7 +44,7 @@ void main() {
           ..get(
               '/foo/bar',
               createFileHandler(
-                  cacheControl: (final _) => null,
+                  cacheControl: (final _, final __) => null,
                   p.join(d.sandbox, 'file.txt')))))
         .addHandler(respondWith((final _) => Response.notFound()));
     final response = await makeRequest(handler, '/foo/bar');
@@ -60,7 +61,7 @@ void main() {
           ..get(
               '/foo/bar',
               createFileHandler(
-                  cacheControl: (final _) => null,
+                  cacheControl: (final _, final __) => null,
                   p.join(d.sandbox, 'file.txt')))))
         .addHandler(respondWith((final _) => Response.notFound()));
     final response = await makeRequest(handler, '/file.txt');
@@ -70,7 +71,8 @@ void main() {
   group('Given the content type header', () {
     test('when inferred from the file path then it is set correctly', () async {
       final handler = createFileHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(handler, '/file.txt');
       expect(response.statusCode, HttpStatus.ok);
       expect(response.mimeType?.primaryType, 'text');
@@ -81,7 +83,8 @@ void main() {
         "when it can't be inferred then it defaults to application/octet-stream",
         () async {
       final handler = createFileHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'random.unknown'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'random.unknown'));
       final response = await makeRequest(handler, '/random.unknown');
       expect(response.statusCode, HttpStatus.ok);
       expect(response.mimeType, MimeType.octetStream);
@@ -92,7 +95,8 @@ void main() {
     test('when bytes from 0 to 4 are requested then it returns partial content',
         () async {
       final handler = createFileHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -111,7 +115,8 @@ void main() {
         'when range at the end overflows from 0 to 9 then it returns partial content',
         () async {
       final handler = createFileHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -133,7 +138,8 @@ void main() {
         'when range at the start overflows from 8 to 9, '
         'then it returns 416 Request Range Not Satisfiable', () async {
       final handler = createFileHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -151,7 +157,8 @@ void main() {
         'when invalid request with start > end is received, '
         'then it returns 416 Request Range Not Satisfiable', () async {
       final handler = createFileHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -168,7 +175,8 @@ void main() {
         'when request with start > end is received, '
         'then it returns 416 Request Range Not Satisfiable', () async {
       final handler = createFileHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -186,7 +194,8 @@ void main() {
     test("when a file doesn't exist then it throws an ArgumentError", () {
       expect(
         () => createFileHandler(
-            cacheControl: (final _) => null, p.join(d.sandbox, 'nothing.txt')),
+            cacheControl: (final _, final __) => null,
+            p.join(d.sandbox, 'nothing.txt')),
         throwsArgumentError,
       );
     });

--- a/test/static/create_file_handler_test.dart
+++ b/test/static/create_file_handler_test.dart
@@ -14,7 +14,8 @@ void main() {
   });
 
   test('Given a file when served then it returns the file contents', () async {
-    final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+    final handler = createFileHandler(
+        cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
     final response = await makeRequest(handler, '/file.txt');
     expect(response.statusCode, HttpStatus.ok);
     expect(response.body.contentLength, 8);
@@ -24,7 +25,11 @@ void main() {
   test('Given a non-matching URL when served then it returns a 404', () async {
     final handler = const Pipeline()
         .addMiddleware(routeWith(Router<Handler>()
-          ..get('/foo/bar', createFileHandler(p.join(d.sandbox, 'file.txt')))))
+          ..get(
+              '/foo/bar',
+              createFileHandler(
+                  cacheControl: (final _) => null,
+                  p.join(d.sandbox, 'file.txt')))))
         .addHandler(respondWith((final _) => Response.notFound()));
     final response = await makeRequest(handler, '/foo/file.txt');
     expect(response.statusCode, HttpStatus.notFound);
@@ -35,7 +40,11 @@ void main() {
       () async {
     final handler = const Pipeline()
         .addMiddleware(routeWith(Router<Handler>()
-          ..get('/foo/bar', createFileHandler(p.join(d.sandbox, 'file.txt')))))
+          ..get(
+              '/foo/bar',
+              createFileHandler(
+                  cacheControl: (final _) => null,
+                  p.join(d.sandbox, 'file.txt')))))
         .addHandler(respondWith((final _) => Response.notFound()));
     final response = await makeRequest(handler, '/foo/bar');
     expect(response.statusCode, HttpStatus.ok);
@@ -48,7 +57,11 @@ void main() {
       () async {
     final handler = const Pipeline()
         .addMiddleware(routeWith(Router<Handler>()
-          ..get('/foo/bar', createFileHandler(p.join(d.sandbox, 'file.txt')))))
+          ..get(
+              '/foo/bar',
+              createFileHandler(
+                  cacheControl: (final _) => null,
+                  p.join(d.sandbox, 'file.txt')))))
         .addHandler(respondWith((final _) => Response.notFound()));
     final response = await makeRequest(handler, '/file.txt');
     expect(response.statusCode, HttpStatus.notFound);
@@ -56,7 +69,8 @@ void main() {
 
   group('Given the content type header', () {
     test('when inferred from the file path then it is set correctly', () async {
-      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final handler = createFileHandler(
+          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(handler, '/file.txt');
       expect(response.statusCode, HttpStatus.ok);
       expect(response.mimeType?.primaryType, 'text');
@@ -66,7 +80,8 @@ void main() {
     test(
         "when it can't be inferred then it defaults to application/octet-stream",
         () async {
-      final handler = createFileHandler(p.join(d.sandbox, 'random.unknown'));
+      final handler = createFileHandler(
+          cacheControl: (final _) => null, p.join(d.sandbox, 'random.unknown'));
       final response = await makeRequest(handler, '/random.unknown');
       expect(response.statusCode, HttpStatus.ok);
       expect(response.mimeType, MimeType.octetStream);
@@ -76,7 +91,8 @@ void main() {
   group('Given the content range header', () {
     test('when bytes from 0 to 4 are requested then it returns partial content',
         () async {
-      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final handler = createFileHandler(
+          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -94,7 +110,8 @@ void main() {
     test(
         'when range at the end overflows from 0 to 9 then it returns partial content',
         () async {
-      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final handler = createFileHandler(
+          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -115,7 +132,8 @@ void main() {
     test(
         'when range at the start overflows from 8 to 9, '
         'then it returns 416 Request Range Not Satisfiable', () async {
-      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final handler = createFileHandler(
+          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -132,7 +150,8 @@ void main() {
     test(
         'when invalid request with start > end is received, '
         'then it returns 416 Request Range Not Satisfiable', () async {
-      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final handler = createFileHandler(
+          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -148,7 +167,8 @@ void main() {
     test(
         'when request with start > end is received, '
         'then it returns 416 Request Range Not Satisfiable', () async {
-      final handler = createFileHandler(p.join(d.sandbox, 'file.txt'));
+      final handler = createFileHandler(
+          cacheControl: (final _) => null, p.join(d.sandbox, 'file.txt'));
       final response = await makeRequest(
         handler,
         '/file.txt',
@@ -165,7 +185,8 @@ void main() {
   group('Given an ArgumentError is thrown for', () {
     test("when a file doesn't exist then it throws an ArgumentError", () {
       expect(
-        () => createFileHandler(p.join(d.sandbox, 'nothing.txt')),
+        () => createFileHandler(
+            cacheControl: (final _) => null, p.join(d.sandbox, 'nothing.txt')),
         throwsArgumentError,
       );
     });

--- a/test/static/default_handler_test.dart
+++ b/test/static/default_handler_test.dart
@@ -17,7 +17,7 @@ void main() {
 
       // Return 403 Forbidden instead of 404 Not Found, as default
       handler = createStaticHandler(
-          cacheControl: (final _) => null,
+          cacheControl: (final _, final __) => null,
           d.sandbox,
           defaultHandler: respondWith((final _) => Response.forbidden()));
     });

--- a/test/static/default_handler_test.dart
+++ b/test/static/default_handler_test.dart
@@ -17,7 +17,7 @@ void main() {
 
       // Return 403 Forbidden instead of 404 Not Found, as default
       handler = createStaticHandler(
-          cacheControl: null,
+          cacheControl: (final _) => null,
           d.sandbox,
           defaultHandler: respondWith((final _) => Response.forbidden()));
     });

--- a/test/static/get_handler_test.dart
+++ b/test/static/get_handler_test.dart
@@ -17,7 +17,7 @@ void main() {
       () async {
     expect(
         () => createStaticHandler(
-            cacheControl: (final _) => null, 'random/relative'),
+            cacheControl: (final _, final __) => null, 'random/relative'),
         throwsArgumentError);
   });
 
@@ -27,7 +27,7 @@ void main() {
     final existingRelative = p.relative(d.sandbox);
     expect(
         () => createStaticHandler(
-            cacheControl: (final _) => null, existingRelative),
+            cacheControl: (final _, final __) => null, existingRelative),
         returnsNormally);
   });
 
@@ -37,7 +37,7 @@ void main() {
     final nonExistingAbsolute = p.join(d.sandbox, 'not_here');
     expect(
         () => createStaticHandler(
-            cacheControl: (final _) => null, nonExistingAbsolute),
+            cacheControl: (final _, final __) => null, nonExistingAbsolute),
         throwsArgumentError);
   });
 
@@ -45,7 +45,8 @@ void main() {
       'Given an existing absolute path when creating a static handler then it returns normally',
       () {
     expect(
-        () => createStaticHandler(cacheControl: (final _) => null, d.sandbox),
+        () => createStaticHandler(
+            cacheControl: (final _, final __) => null, d.sandbox),
         returnsNormally);
   });
 }

--- a/test/static/get_handler_test.dart
+++ b/test/static/get_handler_test.dart
@@ -15,7 +15,9 @@ void main() {
   test(
       'Given a non-existent relative path when creating a static handler then it throws an ArgumentError',
       () async {
-    expect(() => createStaticHandler(cacheControl: null, 'random/relative'),
+    expect(
+        () => createStaticHandler(
+            cacheControl: (final _) => null, 'random/relative'),
         throwsArgumentError);
   });
 
@@ -23,7 +25,9 @@ void main() {
       'Given an existing relative path when creating a static handler then it returns normally',
       () async {
     final existingRelative = p.relative(d.sandbox);
-    expect(() => createStaticHandler(cacheControl: null, existingRelative),
+    expect(
+        () => createStaticHandler(
+            cacheControl: (final _) => null, existingRelative),
         returnsNormally);
   });
 
@@ -31,14 +35,17 @@ void main() {
       'Given a non-existent absolute path when creating a static handler then it throws an ArgumentError',
       () {
     final nonExistingAbsolute = p.join(d.sandbox, 'not_here');
-    expect(() => createStaticHandler(cacheControl: null, nonExistingAbsolute),
+    expect(
+        () => createStaticHandler(
+            cacheControl: (final _) => null, nonExistingAbsolute),
         throwsArgumentError);
   });
 
   test(
       'Given an existing absolute path when creating a static handler then it returns normally',
       () {
-    expect(() => createStaticHandler(cacheControl: null, d.sandbox),
+    expect(
+        () => createStaticHandler(cacheControl: (final _) => null, d.sandbox),
         returnsNormally);
   });
 }

--- a/test/static/if_modified_since_test.dart
+++ b/test/static/if_modified_since_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   test(

--- a/test/static/if_modified_since_test.dart
+++ b/test/static/if_modified_since_test.dart
@@ -12,7 +12,8 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   test(

--- a/test/static/if_none_match_test.dart
+++ b/test/static/if_none_match_test.dart
@@ -75,6 +75,34 @@ void main() {
   });
 
   test(
+      'Given an If-None-Match header with an original ETag that no longer match, '
+      'when a request is made for the file, '
+      'then a 200 OK status is returned with the full body', () async {
+    await d.file('changing', 'before').create();
+
+    final firstResponse = await makeRequest(handler, '/changing');
+    expect(firstResponse.statusCode, 200);
+    expect(await firstResponse.readAsString(), 'before');
+
+    final etag = firstResponse.headers.etag!;
+
+    final secondResponse = await makeRequest(handler, '/changing',
+        headers: Headers.build(
+            (final mh) => mh.ifNoneMatch = IfNoneMatchHeader.etags([etag])));
+
+    expect(secondResponse.statusCode, 304);
+    expect(await secondResponse.readAsString(), isEmpty);
+
+    await d.file('changing', 'after').create();
+
+    final thirdResponse = await makeRequest(handler, '/changing',
+        headers: Headers.build(
+            (final mh) => mh.ifNoneMatch = IfNoneMatchHeader.etags([etag])));
+    expect(thirdResponse.statusCode, 200);
+    expect(await thirdResponse.readAsString(), 'after');
+  });
+
+  test(
       'Given an If-None-Match header with wildcard, '
       'when a request is made for the file, '
       'then a 304 Not Modified status is returned with no body', () async {

--- a/test/static/if_none_match_test.dart
+++ b/test/static/if_none_match_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   test(

--- a/test/static/if_none_match_test.dart
+++ b/test/static/if_none_match_test.dart
@@ -12,7 +12,8 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   test(

--- a/test/static/if_range_test.dart
+++ b/test/static/if_range_test.dart
@@ -13,7 +13,7 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   test(

--- a/test/static/if_range_test.dart
+++ b/test/static/if_range_test.dart
@@ -13,7 +13,8 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   test(

--- a/test/static/mounted_test.dart
+++ b/test/static/mounted_test.dart
@@ -19,7 +19,7 @@ void main() {
       ..get(
           '/**',
           createStaticHandler(
-            cacheControl: (final _) => null,
+            cacheControl: (final _, final __) => null,
             d.sandbox,
           ));
     final handler = const Pipeline()

--- a/test/static/mounted_test.dart
+++ b/test/static/mounted_test.dart
@@ -16,7 +16,12 @@ void main() {
       'when retrieving the same file twice '
       'then it should return 200 Ok both times', () async {
     final router = Router<Handler>()
-      ..get('/**', createStaticHandler(cacheControl: null, d.sandbox));
+      ..get(
+          '/**',
+          createStaticHandler(
+            cacheControl: (final _) => null,
+            d.sandbox,
+          ));
     final handler = const Pipeline()
         .addMiddleware(routeWith(router))
         .addHandler(respondWith((final _) => Response.notFound()));

--- a/test/static/not_found_test.dart
+++ b/test/static/not_found_test.dart
@@ -13,7 +13,8 @@ void main() {
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
     await d.dir('test_directory').create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   test(

--- a/test/static/not_found_test.dart
+++ b/test/static/not_found_test.dart
@@ -13,7 +13,7 @@ void main() {
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
     await d.dir('test_directory').create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   test(

--- a/test/static/range_edge_cases_test.dart
+++ b/test/static/range_edge_cases_test.dart
@@ -15,7 +15,8 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   group('Given malformed Range headers', () {

--- a/test/static/range_edge_cases_test.dart
+++ b/test/static/range_edge_cases_test.dart
@@ -15,7 +15,7 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   group('Given malformed Range headers', () {

--- a/test/static/range_test.dart
+++ b/test/static/range_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   group('Given a single byte range request', () {

--- a/test/static/range_test.dart
+++ b/test/static/range_test.dart
@@ -12,7 +12,8 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   group('Given a single byte range request', () {

--- a/test/static/symbolic_link_test.dart
+++ b/test/static/symbolic_link_test.dart
@@ -45,8 +45,8 @@ void main() {
       'when accessing a sym linked file in a real dir, '
       'then it returns the file content',
       () async {
-        final handler =
-            createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+        final handler = createStaticHandler(
+            cacheControl: (final _, final __) => null, d.sandbox);
 
         final response = await makeRequest(handler, '/link_index.html');
         expect(response.statusCode, HttpStatus.ok);
@@ -58,8 +58,8 @@ void main() {
     test(
         'when accessing a file in a sym linked dir, '
         'then it returns the file content', () async {
-      final handler =
-          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+      final handler = createStaticHandler(
+          cacheControl: (final _, final __) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/link_dir/index.html');
       expect(response.statusCode, HttpStatus.ok);
@@ -73,7 +73,8 @@ void main() {
         'when accessing a sym linked file in a real dir, '
         'then it returns a 404', () async {
       final handler = createStaticHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'alt_root'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'alt_root'));
 
       final response = await makeRequest(handler, '/link_index.html');
       expect(response.statusCode, HttpStatus.notFound);
@@ -83,7 +84,8 @@ void main() {
         'when accessing a real file in a sym linked dir, '
         'then it returns a 404', () async {
       final handler = createStaticHandler(
-          cacheControl: (final _) => null, p.join(d.sandbox, 'alt_root'));
+          cacheControl: (final _, final __) => null,
+          p.join(d.sandbox, 'alt_root'));
 
       final response = await makeRequest(handler, '/link_dir/index.html');
       expect(response.statusCode, HttpStatus.notFound);

--- a/test/static/symbolic_link_test.dart
+++ b/test/static/symbolic_link_test.dart
@@ -45,7 +45,8 @@ void main() {
       'when accessing a sym linked file in a real dir, '
       'then it returns the file content',
       () async {
-        final handler = createStaticHandler(cacheControl: null, d.sandbox);
+        final handler =
+            createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
         final response = await makeRequest(handler, '/link_index.html');
         expect(response.statusCode, HttpStatus.ok);
@@ -57,7 +58,8 @@ void main() {
     test(
         'when accessing a file in a sym linked dir, '
         'then it returns the file content', () async {
-      final handler = createStaticHandler(cacheControl: null, d.sandbox);
+      final handler =
+          createStaticHandler(cacheControl: (final _) => null, d.sandbox);
 
       final response = await makeRequest(handler, '/link_dir/index.html');
       expect(response.statusCode, HttpStatus.ok);
@@ -71,7 +73,7 @@ void main() {
         'when accessing a sym linked file in a real dir, '
         'then it returns a 404', () async {
       final handler = createStaticHandler(
-          cacheControl: null, p.join(d.sandbox, 'alt_root'));
+          cacheControl: (final _) => null, p.join(d.sandbox, 'alt_root'));
 
       final response = await makeRequest(handler, '/link_index.html');
       expect(response.statusCode, HttpStatus.notFound);
@@ -81,7 +83,7 @@ void main() {
         'when accessing a real file in a sym linked dir, '
         'then it returns a 404', () async {
       final handler = createStaticHandler(
-          cacheControl: null, p.join(d.sandbox, 'alt_root'));
+          cacheControl: (final _) => null, p.join(d.sandbox, 'alt_root'));
 
       final response = await makeRequest(handler, '/link_dir/index.html');
       expect(response.statusCode, HttpStatus.notFound);

--- a/test/static/unsupported_methods_test.dart
+++ b/test/static/unsupported_methods_test.dart
@@ -12,7 +12,8 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
+    handler = createStaticHandler(
+        cacheControl: (final _, final __) => null, d.sandbox);
   });
 
   group('Given unsupported HTTP methods', () {

--- a/test/static/unsupported_methods_test.dart
+++ b/test/static/unsupported_methods_test.dart
@@ -12,7 +12,7 @@ void main() {
 
   setUp(() async {
     await d.file('test_file.txt', fileContent).create();
-    handler = createStaticHandler(cacheControl: null, d.sandbox);
+    handler = createStaticHandler(cacheControl: (final _) => null, d.sandbox);
   });
 
   group('Given unsupported HTTP methods', () {


### PR DESCRIPTION
## Description

Allow Cache-Control header to be set per file.

## Related Issues
- Closes: #168 

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.

Changes the interface of `createStaticHandler` and  `createFileHandler`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Static and file handlers now support a per-file Cache-Control callback, enabling tailored caching headers.
  - Handlers receive richer file metadata to inform caching and response behavior.
- Bug Fixes
  - More robust content-type detection, including safer handling of empty files.
  - Improved consistency for range and conditional requests (If-Range, ETag/Last-Modified).
- Refactor
  - Unified file metadata flow across file-serving paths for clearer, more reliable behavior.
- Documentation
  - Minor wording improvements in comments to clarify GET/HEAD behavior and caching notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->