### PR TITLE
refactor: Rip out Router.staticCache

### DIFF
--- a/test/static/mounted_test.dart
+++ b/test/static/mounted_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:relic/relic.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'test_util.dart';
+
+void main() {
+  setUp(() async {
+    await d.file('root.txt', 'root txt').create();
+  });
+
+  test(
+      'Given a static handler mounted on a router under "/**" '
+      'when retrieving the same file twice '
+      'then it should return 200 Ok both times', () async {
+    final router = Router<Handler>()
+      ..get('/**', createStaticHandler(cacheControl: null, d.sandbox));
+    final handler = const Pipeline()
+        .addMiddleware(routeWith(router))
+        .addHandler(respondWith((final _) => Response.notFound()));
+
+    // Repeat retrieveal. This test was added to expose issue:
+    // [#173](https://github.com/serverpod/relic/issues/173)
+    int repeat = 2;
+    while (repeat-- > 0) {
+      final response = await makeRequest(handler, '/root.txt');
+      expect(response.statusCode, HttpStatus.ok);
+    }
+  });
+}


### PR DESCRIPTION
## Description

This PR disables an optimization in the `Router` regarding static paths, ie. paths without any dynamic elements (`/:id/, /*/, /**`).

It does so because a bug was identified that caused `LookupResult` to contain wrong `matched` and `remaining` properties on subsequent lookups in certain cases.



## Related Issues
Fixes: #173

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [x] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [ ] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.

This just disables an internal optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes.
- Performance
  - Reduced memory overhead and simplified route lookups by removing redundant caching, improving consistency under dynamic route updates.
- Refactor
  - Simplified routing internals without altering public APIs or configuration.
- Bug Fixes
  - None.
- Documentation
  - None.
- Tests
  - None.
- Chores
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->