### PR TITLE
fix: Build platform correct path when serving files.

### DIFF
--- a/lib/src/io/static/static_handler.dart
+++ b/lib/src/io/static/static_handler.dart
@@ -74,8 +74,8 @@ Handler createStaticHandler(
       defaultHandler ?? respondWith((final _) => Response.notFound());
 
   return (final NewContext ctx) async {
-    final requestPath = ctx.remainingPath.path;
-    final filePath = p.join(resolvedRootPath, requestPath.substring(1));
+    final filePath =
+        p.joinAll([resolvedRootPath, ...ctx.remainingPath.segments]);
 
     // Ensure file exists and is not a directory
     final entityType = FileSystemEntity.typeSync(filePath, followLinks: false);


### PR DESCRIPTION
Fixes a minor issue where we would not build valid paths for the windows platform when serving files.

Before this fix, given a static root directory located at `C:\\my\static\root\` and a request path for a file located at `assets/image.png` the following path would be constructed `C:\\my\static\root\assets/image.png` (Note the mix of forward and backward slashes).

Windows handles this gracefully, so can't catch this in the tests, but it was incorrect behavior.

If you have a suggestion on how to capture this in the tests I would appreciate it.

## Pre-Launch Checklist
Please ensure that your PR meets the following requirements before submitting:

- [ ] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [ ] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [ ] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [ ] I have added new tests to verify the changes.
- [ ] All existing and new tests pass successfully.
- [ ] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.

Simple path fix.
