### PR TITLE
feat: Introduce MiddlewareObject

### DIFF
--- a/lib/relic.dart
+++ b/lib/relic.dart
@@ -20,7 +20,7 @@ export 'src/io/static/static_handler.dart';
 export 'src/message/request.dart' show Request;
 export 'src/message/response.dart' show Response;
 export 'src/middleware/context_property.dart';
-export 'src/middleware/middleware.dart' show Middleware, createMiddleware;
+export 'src/middleware/middleware.dart';
 export 'src/middleware/middleware_extensions.dart' show MiddlewareExtensions;
 export 'src/middleware/middleware_logger.dart' show logRequests;
 export 'src/middleware/routing_middleware.dart';

--- a/lib/src/middleware/middleware.dart
+++ b/lib/src/middleware/middleware.dart
@@ -1,9 +1,6 @@
 import 'dart:async';
 
-import '../adapter/context.dart';
-import '../handler/handler.dart';
-import '../message/request.dart';
-import '../message/response.dart';
+import '../../relic.dart';
 
 /// A function which creates a new [Handler] by wrapping a [Handler].
 ///
@@ -69,4 +66,28 @@ Middleware createMiddleware({
       return responseCtx.respond(response);
     };
   };
+}
+
+/// An abstract base class for classes that behave like [Middleware].
+///
+/// Instances of [MiddlewareObject] are callable as [Middleware], and
+/// can be passed as middleware via a [call] tear-off.
+///
+/// Overriding [call] is mandatory.
+///
+/// If the middleware requires special path parameters, then you should
+/// override [injectIn].
+abstract class MiddlewareObject implements RouterInjectable {
+  /// Use this middleware on [router] on path `/`.
+  /// Override to use on a different path.
+  @override
+  void injectIn(final Router<Handler> router) => router.use('/', call);
+
+  /// The implementation of this [MiddlewareObject]
+  Handler call(final Handler next);
+
+  /// Returns this [MiddlewareObject] as a [Middleware] function.
+  Middleware get asMiddleware => call;
+
+  const MiddlewareObject();
 }

--- a/test/middleware/middleware_object_test.dart
+++ b/test/middleware/middleware_object_test.dart
@@ -1,0 +1,136 @@
+import 'package:relic/relic.dart';
+import 'package:relic/src/adapter/context.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MiddlewareObject', () {
+    test(
+        'Given a MiddlewareObject, '
+        'when used as middleware via call, '
+        'then it wraps the handler correctly', () async {
+      final middlewareObject = _TestMiddlewareObject();
+      final router = Router<Handler>();
+      router.use('/', middlewareObject.call);
+      router.get('/test', (final ctx) => ctx.respond(Response.ok()));
+
+      final request = Request(Method.get, Uri.parse('http://localhost/test'));
+      final ctx = request.toContext(Object());
+      final result = await router.asHandler(ctx) as ResponseContext;
+
+      expect(result.response.statusCode, 200);
+      expect(result.response.headers['X-Middleware'], ['applied']);
+    });
+
+    test(
+        'Given a MiddlewareObject, '
+        'when asMiddleware getter is used, '
+        'then it returns a valid Middleware function', () async {
+      final middlewareObject = _TestMiddlewareObject();
+      final middleware = middlewareObject.asMiddleware;
+
+      // Verify it's callable as a Middleware
+      expect(middleware, isA<Middleware>());
+
+      final router = Router<Handler>();
+      router.use('/', middleware);
+      router.get('/test', (final ctx) => ctx.respond(Response.ok()));
+
+      final request = Request(Method.get, Uri.parse('http://localhost/test'));
+      final ctx = request.toContext(Object());
+      final result = await router.asHandler(ctx) as ResponseContext;
+
+      expect(result.response.statusCode, 200);
+      expect(result.response.headers['X-Middleware'], ['applied']);
+    });
+
+    test(
+        'Given a MiddlewareObject that modifies requests, '
+        'when it wraps a handler, '
+        'then the handler receives the modified context', () async {
+      final middlewareObject = _RequestModifyingMiddleware();
+      final router = Router<Handler>();
+      router.use('/', middlewareObject.call);
+
+      String? capturedHeader;
+      router.get('/test', (final ctx) {
+        capturedHeader = ctx.request.headers['X-Added']?.first;
+        return ctx.respond(Response.ok());
+      });
+
+      final request = Request(Method.get, Uri.parse('http://localhost/test'));
+      final ctx = request.toContext(Object());
+      await router.asHandler(ctx);
+
+      expect(capturedHeader, 'by-middleware');
+    });
+
+    test(
+        'Given a MiddlewareObject that can short-circuit, '
+        'when it returns early, '
+        'then the inner handler is not called', () async {
+      final middlewareObject = _ShortCircuitMiddleware();
+      final router = Router<Handler>();
+      router.use('/', middlewareObject.call);
+
+      var innerHandlerCalled = false;
+      router.get('/test', (final ctx) {
+        innerHandlerCalled = true;
+        return ctx.respond(Response.ok());
+      });
+
+      final request = Request(Method.get, Uri.parse('http://localhost/test'));
+      final ctx = request.toContext(Object());
+      final result = await router.asHandler(ctx) as ResponseContext;
+
+      expect(innerHandlerCalled, isFalse);
+      expect(result.response.statusCode, 403);
+      expect(await result.response.readAsString(), 'Forbidden');
+    });
+  });
+}
+
+// Test implementations
+class _TestMiddlewareObject extends MiddlewareObject {
+  @override
+  Handler call(final Handler next) {
+    return (final ctx) async {
+      final result = await next(ctx);
+      if (result is! ResponseContext) return result;
+      return result.respond(
+        result.response.copyWith(
+          headers: result.response.headers.transform(
+            (final h) => h['X-Middleware'] = ['applied'],
+          ),
+        ),
+      );
+    };
+  }
+}
+
+class _RequestModifyingMiddleware extends MiddlewareObject {
+  @override
+  Handler call(final Handler next) {
+    return (final ctx) async {
+      // Modify the request by adding a header
+      final modifiedRequest = ctx.request.copyWith(
+        headers: ctx.request.headers.transform(
+          (final h) => h['X-Added'] = ['by-middleware'],
+        ),
+      );
+      final modifiedCtx = ctx.withRequest(modifiedRequest);
+      return next(modifiedCtx);
+    };
+  }
+}
+
+class _ShortCircuitMiddleware extends MiddlewareObject {
+  @override
+  Handler call(final Handler next) {
+    return (final ctx) async {
+      // Short-circuit without calling next
+      return ctx.respond(
+        Response.forbidden(body: Body.fromString('Forbidden')),
+      );
+    };
+  }
+}

--- a/test/router/router_inject_test.dart
+++ b/test/router/router_inject_test.dart
@@ -39,6 +39,76 @@ void main() {
       expect(await result.response.readAsString(), 'custom handler');
     });
   });
+
+  group('Router.inject with MiddlewareObject', () {
+    test(
+        'Given a MiddlewareObject, '
+        'when injected into router, '
+        'then it is registered with default injectIn behavior at root path',
+        () async {
+      final router = Router<Handler>();
+      router.inject(_HeaderSetMiddlewareObject(
+          (final mh) => mh['X-Middleware'] = ['applied']));
+      router.get('/test', (final ctx) => ctx.respond(Response.ok()));
+
+      final request = Request(Method.get, Uri.parse('http://localhost/test'));
+      final ctx = request.toContext(Object());
+      final result = await router.asHandler(ctx) as ResponseContext;
+
+      expect(result.response.statusCode, 200);
+      expect(result.response.headers['X-Middleware'], ['applied']);
+    });
+
+    test(
+        'Given a MiddlewareObject with custom injectIn, '
+        'when injected into router, '
+        'then custom path is used', () async {
+      final router = Router<Handler>();
+      router.inject(_HeaderSetMiddlewareObject(
+          (final mh) => mh['X-Custom-Middleware'] = ['yes'],
+          mountAt: '/api'));
+      router.get('/api/users', (final ctx) => ctx.respond(Response.ok()));
+      router.get('/other', (final ctx) => ctx.respond(Response.ok()));
+
+      // Should apply to /api/* paths
+      final apiRequest =
+          Request(Method.get, Uri.parse('http://localhost/api/users'));
+      final apiCtx = apiRequest.toContext(Object());
+      final apiResult = await router.asHandler(apiCtx) as ResponseContext;
+
+      expect(apiResult.response.statusCode, 200);
+      expect(apiResult.response.headers['X-Custom-Middleware'], ['yes']);
+
+      // Should NOT apply to other paths
+      final otherRequest =
+          Request(Method.get, Uri.parse('http://localhost/other'));
+      final otherCtx = otherRequest.toContext(Object());
+      final otherResult = await router.asHandler(otherCtx) as ResponseContext;
+
+      expect(otherResult.response.statusCode, 200);
+      expect(otherResult.response.headers['X-Custom-Middleware'], isNull);
+    });
+
+    test(
+        'Given multiple MiddlewareObjects, '
+        'when injected into router, '
+        'then they are all registered and compose correctly', () async {
+      final router = Router<Handler>();
+      router.inject(_HeaderSetMiddlewareObject(
+          (final mh) => mh['X-Middleware'] = ['applied']));
+      router.inject(_HeaderSetMiddlewareObject(
+          (final mh) => mh['X-Second'] = ['also-applied']));
+      router.get('/test', (final ctx) => ctx.respond(Response.ok()));
+
+      final request = Request(Method.get, Uri.parse('http://localhost/test'));
+      final ctx = request.toContext(Object());
+      final result = await router.asHandler(ctx) as ResponseContext;
+
+      expect(result.response.statusCode, 200);
+      expect(result.response.headers['X-Middleware'], ['applied']);
+      expect(result.response.headers['X-Second'], ['also-applied']);
+    });
+  });
 }
 
 // Test implementations - HandlerObject
@@ -56,5 +126,28 @@ class _EchoHandlerObject extends HandlerObject {
     return ctx.respond(
       Response.ok(body: Body.fromDataStream(data)),
     );
+  }
+}
+
+// Test implementations - MiddlewareObject
+class _HeaderSetMiddlewareObject extends MiddlewareObject {
+  final void Function(MutableHeaders) update;
+  final String mountAt;
+
+  _HeaderSetMiddlewareObject(this.update, {this.mountAt = '/'});
+
+  @override
+  void injectIn(final Router<Handler> router) => router.use(mountAt, call);
+
+  @override
+  Handler call(final Handler next) {
+    return (final ctx) async {
+      final result = await next(ctx);
+      if (result is! ResponseContext) return result;
+      return result.respond(
+        result.response
+            .copyWith(headers: result.response.headers.transform(update)),
+      );
+    };
   }
 }


### PR DESCRIPTION
## Description
This PR introduces the `MiddlewareObject` abstraction, mirroring the `HandlerObject` pattern for middleware.

- Add `MiddlewareObject` abstract class that implements `RouterInjectable`, allowing middleware objects to be callable and define custom routing via `injectIn` method
- Add `asMiddleware` getter to `MiddlewareObject` for obtaining a `Middleware` function reference
- Export entire `middleware.dart` module from `relic.dart`
- Add comprehensive tests for `MiddlewareObject` functionality including:
  - Default injection behavior at root path
  - Custom path injection via `injectIn` override
  - Multiple middleware composition
  - Request modification and short-circuiting behavior
- Add integration tests for `Router.inject` with `MiddlewareObject`s

This complements the `HandlerObject` abstraction by providing the same encapsulation pattern for middleware, allowing middleware logic and routing configuration to be bundled in a single reusable object.

## Related Issues
- Fixes: #221 
- Fixes: #219 

## Pre-Launch Checklist
- [x] This update focuses on a single feature or bug fix.
- [x] I have read and followed the Dart Style Guide and formatted the code using dart format.
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`).
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.

## Additional Notes
The `MiddlewareObject` follows the same design pattern as `HandlerObject`, providing consistency across the API. Both classes implement `RouterInjectable` and can be mounted using `Router.inject`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced MiddlewareObject for object-based middleware, with a default inject behavior and a const constructor.
  * MiddlewareObject can be used directly or via asMiddleware, supports modifying requests/responses, and can short-circuit with custom responses.
  * Supports router injection at root or custom mount paths, and composing multiple middleware objects.
  * Expanded public middleware exports to expose all middleware utilities.

* **Tests**
  * Added comprehensive tests covering MiddlewareObject usage, request/response transformation, short-circuiting, router injection, mount paths, and multiple middleware composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->