### PR TITLE
docs: Update code block references to use local file paths in documentation

### DIFF
--- a/doc/site/docs/01-getting-started/03-shelf-migration.md
+++ b/doc/site/docs/01-getting-started/03-shelf-migration.md
@@ -73,7 +73,7 @@ void main() async {
 
 Relic:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/relic_shelf.dart) doctag="complete-relic"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/relic_shelf.dart" doctag="complete-relic"
 
 ### 3. Update handler signatures
 
@@ -247,7 +247,7 @@ var handler = webSocketHandler((webSocket) {
 
 Relic has WebSockets built-in without the need for a separate package:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/relic_shelf.dart) doctag="websocket-relic"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/relic_shelf.dart" doctag="websocket-relic"
 
 ## Example comparison
 
@@ -277,7 +277,7 @@ void main() async {
 
 ### Relic version
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/relic_shelf.dart) doctag="complete-relic"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/relic_shelf.dart" doctag="complete-relic"
 
 :::info Difference from Shelf's pipeline
 Unlike Shelf's `Pipeline().addMiddleware()`, which runs for _all_ requests (including 404s), Relic's `.use('/', ...)` only executes middleware for requests that match a route. Unmatched requests (404s) bypass middleware and go directly to the fallback handler.

--- a/doc/site/docs/02-reference/01-handlers.md
+++ b/doc/site/docs/02-reference/01-handlers.md
@@ -25,7 +25,7 @@ typedef Handler = FutureOr<Result> Function(Request req);
 
 **Example:**
 
-GITHUB_CODE_BLOCK lang="dart" doctag="handler-foundational" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/handler.dart) title="Foundational handler example"
+GITHUB_CODE_BLOCK lang="dart" doctag="handler-foundational" file="../_example/basic/handler.dart" title="Foundational handler example"
 
 ## How to define handlers
 
@@ -33,31 +33,31 @@ GITHUB_CODE_BLOCK lang="dart" doctag="handler-foundational" [src](https://raw.gi
 
 For simple, fast operations:
 
-GITHUB_CODE_BLOCK lang="dart" doctag="handler-sync" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/handler.dart) title="Synchronous handler"
+GITHUB_CODE_BLOCK lang="dart" doctag="handler-sync" file="../_example/basic/handler.dart" title="Synchronous handler"
 
 ### Asynchronous handlers
 
 For operations that need to wait (database calls, file I/O, etc.):
 
-GITHUB_CODE_BLOCK lang="dart" doctag="handler-async" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/handler.dart) title="Asynchronous handler"
+GITHUB_CODE_BLOCK lang="dart" doctag="handler-async" file="../_example/basic/handler.dart" title="Asynchronous handler"
 
 ### Using request data
 
 Handlers receive request information including method, URL, headers, and query parameters:
 
-GITHUB_CODE_BLOCK lang="dart" doctag="handler-context" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/handler.dart) title="Using request data"
+GITHUB_CODE_BLOCK lang="dart" doctag="handler-context" file="../_example/basic/handler.dart" title="Using request data"
 
 ### Handling WebSocket connections
 
 For real-time bidirectional communication, you can upgrade connections to WebSockets by returning a `WebSocketUpgrade`:
 
-GITHUB_CODE_BLOCK lang="dart" doctag="context-websocket-echo" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/context/context.dart) title="WebSocket example"
+GITHUB_CODE_BLOCK lang="dart" doctag="context-websocket-echo" file="../_example/context/context.dart" title="WebSocket example"
 
 ### Hijacking connections
 
 For advanced use cases like Server-Sent Events (SSE) or custom protocols, you can hijack the connection:
 
-GITHUB_CODE_BLOCK lang="dart" doctag="handler-hijack-sse" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/handler.dart) title="Connection hijacking example"
+GITHUB_CODE_BLOCK lang="dart" doctag="handler-hijack-sse" file="../_example/basic/handler.dart" title="Connection hijacking example"
 
 ## Examples & further reading
 

--- a/doc/site/docs/02-reference/02-context.md
+++ b/doc/site/docs/02-reference/02-context.md
@@ -44,13 +44,13 @@ Context properties provide the following methods:
 
 Set values in middleware or handlers using the `[]` operator:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/context/context_property.dart) doctag="context-prop-request-id" title="Add request ID to context"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/context/context_property.dart" doctag="context-prop-request-id" title="Add request ID to context"
 
 ### Reading properties
 
 Read values with `property[req]` (throws if missing) or `property.getOrNull(req)`:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/context/context_property.dart) doctag="context-prop-use-request-id" title="Use request ID from context"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/context/context_property.dart" doctag="context-prop-use-request-id" title="Use request ID from context"
 
 :::info Property lifetime
 Context properties exist **only for the duration of the request**. Once the response is sent, they're automatically cleaned up. Values are scoped to each request and do not leak between requests.

--- a/doc/site/docs/02-reference/03-routing.md
+++ b/doc/site/docs/02-reference/03-routing.md
@@ -49,19 +49,19 @@ These are convenience methods for the core `.add()` method:
 
 **Respond with `Hello World!` on the homepage:**
 
-GITHUB_CODE_BLOCK lang="dart" title="GET /" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/basic_routing.dart) doctag="routing-get-root"
+GITHUB_CODE_BLOCK lang="dart" title="GET /" file="../_example/routing/basic_routing.dart" doctag="routing-get-root"
 
 **Respond to a POST request on the root route:**
 
-GITHUB_CODE_BLOCK lang="dart" title="POST /" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/basic_routing.dart) doctag="routing-post-root"
+GITHUB_CODE_BLOCK lang="dart" title="POST /" file="../_example/routing/basic_routing.dart" doctag="routing-post-root"
 
 **Respond to a PUT request to the `/user` route:**
 
-GITHUB_CODE_BLOCK lang="dart" title="PUT /user" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/basic_routing.dart) doctag="routing-put-user"
+GITHUB_CODE_BLOCK lang="dart" title="PUT /user" file="../_example/routing/basic_routing.dart" doctag="routing-put-user"
 
 **Respond to a DELETE request to the `/user` route:**
 
-GITHUB_CODE_BLOCK lang="dart" title="DELETE /user" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/basic_routing.dart) doctag="routing-delete-user"
+GITHUB_CODE_BLOCK lang="dart" title="DELETE /user" file="../_example/routing/basic_routing.dart" doctag="routing-delete-user"
 
 ### Using the `add` method
 
@@ -69,7 +69,7 @@ This is what the convenience methods call internally:
 
 **Respond to a PATCH request using the core `.add()` method:**
 
-GITHUB_CODE_BLOCK lang="dart" title="PATCH /api" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/basic_routing.dart) doctag="routing-patch-api"
+GITHUB_CODE_BLOCK lang="dart" title="PATCH /api" file="../_example/routing/basic_routing.dart" doctag="routing-patch-api"
 
 ### Using `anyOf` for multiple methods
 
@@ -77,7 +77,7 @@ Handle multiple HTTP methods with the same handler:
 
 **Handle both GET and POST requests to `/admin`:**
 
-GITHUB_CODE_BLOCK lang="dart" title="GET|POST /admin" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/basic_routing.dart) doctag="routing-anyof-admin"
+GITHUB_CODE_BLOCK lang="dart" title="GET|POST /admin" file="../_example/routing/basic_routing.dart" doctag="routing-anyof-admin"
 
 ## Path parameters, wildcards, and tail segments
 

--- a/doc/site/docs/02-reference/04-requests.md
+++ b/doc/site/docs/02-reference/04-requests.md
@@ -35,7 +35,7 @@ The `Request` object exposes several important properties:
 
 The request method indicates what action the client wants to perform. Relic uses a type-safe `Method` enum rather than strings, which prevents typos and provides better IDE support.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="basic-request-response" title="HTTP method"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="basic-request-response" title="HTTP method"
 
 Common methods include `Method.get`, `Method.post`, `Method.put`, `Method.delete`, `Method.patch`, and `Method.options`.
 
@@ -43,7 +43,7 @@ Common methods include `Method.get`, `Method.post`, `Method.put`, `Method.delete
 
 The `url` property provides the relative path and query parameters from the current handler's perspective. This is particularly useful when your handler is mounted at a specific path prefix.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="path-params-complete" title="Path parameters and URL"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="path-params-complete" title="Path parameters and URL"
 
 ## Working with query parameters
 
@@ -53,7 +53,7 @@ Query parameters are key-value pairs appended to the URL after a question mark (
 
 You can access individual query parameter values through the `queryParameters` map. Each parameter is returned as a string, or null if not present.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="query-params-complete" title="Query parameters"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="query-params-complete" title="Query parameters"
 
 When a client requests `/search?query=relic&page=2`, the query variable will contain `"relic"` and the page variable will contain `"2"`. Both values are strings, so you'll need to parse them if you need other types like integers.
 
@@ -61,7 +61,7 @@ When a client requests `/search?query=relic&page=2`, the query variable will con
 
 Some query parameters can appear multiple times in a URL to represent lists or arrays. The `queryParametersAll` map provides access to all values for each parameter name.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="query-multi-complete" title="Multiple query values"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="query-multi-complete" title="Multiple query values"
 
 For a request to `/filter?tag=dart&tag=server&tag=web`, the tags variable will be a list containing `["dart", "server", "web"]`. This allows you to handle multiple selections or filters cleanly.
 
@@ -73,7 +73,7 @@ HTTP headers carry metadata about the request, such as content type, authenticat
 
 Instead of working with raw string values, Relic's type-safe headers give you properly typed objects. This eliminates parsing errors and provides better code completion in your IDE.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="headers-complete" title="Type-safe headers"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="headers-complete" title="Type-safe headers"
 
 In this example, the `mimeType` is automatically parsed into a `MimeType` object, and `contentLength` is parsed into an integer rather than a string. This type safety helps catch errors at compile time.
 
@@ -81,7 +81,7 @@ In this example, the `mimeType` is automatically parsed into a `MimeType` object
 
 The `authorization` header receives special handling in Relic to distinguish between different authentication schemes like Bearer tokens and Basic authentication.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="auth-complete" title="Authorization header parsing"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="auth-complete" title="Authorization header parsing"
 
 Relic automatically parses the authorization header and creates the appropriate header object type, making it easy to handle different authentication schemes in a type-safe manner.
 
@@ -109,7 +109,7 @@ final body = await request.readAsString();
 
 The most common way to read the body is as a string, which works well for JSON, XML, or plain text data. The `readAsString` method automatically handles character encoding based on the Content-Type header.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="body-handling-complete" title="Read body as string"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="body-handling-complete" title="Read body as string"
 
 The method defaults to UTF-8 encoding if no encoding is specified in the request headers.
 
@@ -117,7 +117,7 @@ The method defaults to UTF-8 encoding if no encoding is specified in the request
 
 For JSON APIs, you'll typically read the body as a string and then decode it using Dart's `jsonDecode` function. This two-step process gives you control over error handling.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="json-api-complete" title="Parse JSON body with validation"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="json-api-complete" title="Parse JSON body with validation"
 
 This example shows proper validation of both the JSON structure and the required fields, providing clear error messages when something is wrong.
 
@@ -125,7 +125,7 @@ This example shows proper validation of both the JSON structure and the required
 
 For large files or binary data, you can read the body as a stream of bytes to avoid loading everything into memory at once. This is essential for handling file uploads or large payloads efficiently.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="upload-complete" title="Read body as byte stream"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="upload-complete" title="Read body as byte stream"
 
 By processing the data in chunks, your server can handle large uploads without running out of memory.
 
@@ -137,7 +137,7 @@ Before attempting to read the body, you can check if it's empty using the `isEmp
 `isEmpty` is based on the known content length when available. For requests using chunked transfer encoding (unknown length up front), `isEmpty` may return `false` even if no data is ultimately sent. Prefer defensive reads for streaming uploads.
 :::
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="upload-complete" title="Body empty check"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="upload-complete" title="Body empty check"
 
 This check doesn't consume the body stream, so you can still read the body afterward.
 

--- a/doc/site/docs/02-reference/05-responses.md
+++ b/doc/site/docs/02-reference/05-responses.md
@@ -28,7 +28,7 @@ Success responses (2xx status codes) indicate that the request was received, und
 
 The most common response indicates the request succeeded and returns the requested data:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="basic-request-response" title="200 OK text response"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="basic-request-response" title="200 OK text response"
 
 ### Error responses
 
@@ -38,13 +38,13 @@ Error responses (4xx, 5xx status codes) indicate that the request was invalid or
 
 The request is malformed or contains invalid data:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="json-api-complete" title="400 Bad Request JSON error"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="json-api-complete" title="400 Bad Request JSON error"
 
 ### Custom status codes
 
 For status codes without a dedicated constructor, use the general `Response` constructor:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="custom-status" title="Custom status code"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="custom-status" title="Custom status code"
 
 :::tip
 For a comprehensive list of HTTP status codes, check out [Mozilla's HTTP Status Codes documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
@@ -60,7 +60,7 @@ The response body contains the actual data you're sending to the client. Relic's
 
 For plain text responses, use `Body.fromString()`:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="basic-request-response" title="Text response"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="basic-request-response" title="Text response"
 
 By default, Relic infers the MIME type from the content. For plain text, it sets `text/plain`.
 
@@ -68,19 +68,19 @@ By default, Relic infers the MIME type from the content. For plain text, it sets
 
 To serve HTML content, specify the MIME type explicitly:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="html-response" title="HTML response"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="html-response" title="HTML response"
 
 ### JSON responses
 
 For JSON APIs, encode your data and specify the JSON MIME type:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="path-params-complete" title="JSON response"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="path-params-complete" title="JSON response"
 
 ### Binary data
 
 For images, PDFs, or other binary content, use `Body.fromData()`:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="binary-response" title="Binary response"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="binary-response" title="Binary response"
 
 Relic automatically infers the MIME type from the binary data when possible.
 
@@ -88,19 +88,19 @@ Relic automatically infers the MIME type from the binary data when possible.
 
 For large files or generated content, stream the data instead of loading it all into memory:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="streaming-response" title="Streaming response"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="streaming-response" title="Streaming response"
 
 ### Empty responses
 
 Some responses don't need a body. Use `Body.empty()` or simply omit the body parameter:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="empty-responses" title="Empty responses"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="empty-responses" title="Empty responses"
 
 ## Setting response headers
 
 Headers provide metadata about your response. Use the `Headers` class to build type-safe headers:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/routing/request_response.dart) doctag="response-headers" title="Set response headers"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/routing/request_response.dart" doctag="response-headers" title="Set response headers"
 
 :::tip
 For a comprehensive list of HTTP headers, check out [Mozilla's HTTP Headers documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).

--- a/doc/site/docs/02-reference/06-body.md
+++ b/doc/site/docs/02-reference/06-body.md
@@ -260,7 +260,7 @@ if (length != null) {
 
 Relic's stream-based approach makes it practical to handle large payloads without exhausting memory, since data is processed incrementally. This pattern is especially helpful for uploads and transformations that work chunk by chunk.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/body.dart) doctag="body-upload-validate-size" title="Validate upload size"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/body.dart" doctag="body-upload-validate-size" title="Validate upload size"
 
 ### One-time read constraint
 
@@ -288,25 +288,25 @@ try {
 
 This example reads JSON input from the request, logs it for observability, and returns a JSON response. The body helper detects JSON automatically, and the explicit MIME type makes the intent clear to both clients and maintainers:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/body.dart) doctag="body-json-api-handler" title="JSON API handler"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/body.dart" doctag="body-json-api-handler" title="JSON API handler"
 
 ### File upload handler
 
 This handler validates the upload size before reading the stream, then writes the content directly to disk. Streaming avoids buffering the entire file in memory and keeps the server responsive under heavy load:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/body.dart) doctag="body-upload-validate-size" title="File upload handler"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/body.dart" doctag="body-upload-validate-size" title="File upload handler"
 
 ### Image response
 
 Here the server reads an SVG file from disk and returns it as binary data. The SVG type must be set explicitly with `MimeType.parse('image/svg+xml')` so clients receive the correct Content-Type.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/body.dart) doctag="body-image-auto-format" title="Serve image (SVG) response"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/body.dart" doctag="body-image-auto-format" title="Serve image (SVG) response"
 
 ### Streaming response
 
 This endpoint produces a stream of JSON lines to demonstrate chunked transfer encoding. Clients can start processing data as soon as it becomes available, which is useful for progress updates and long-running computations:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/body.dart) doctag="body-streaming-chunked" title="Streaming response (chunked)"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/body.dart" doctag="body-streaming-chunked" title="Streaming response (chunked)"
 
 ## Examples & further reading
 

--- a/doc/site/docs/02-reference/07-middleware.md
+++ b/doc/site/docs/02-reference/07-middleware.md
@@ -173,7 +173,7 @@ Middleware layers wrap each other like an onion. Each layer may:
 - Rewrite parts of the request before calling `next(newRequest)`.
 - Prefer attaching derived/computed data to the context via `ContextProperty` rather than rewriting the request.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/middleware/auth.dart) doctag="middleware-auth-basic" title="Basic auth middleware"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/middleware/auth.dart" doctag="middleware-auth-basic" title="Basic auth middleware"
 
 :::warning Avoid rewriting `request.url` in middleware attached with `router.use`.
 When middleware is attached with `router.use(...)`, the request has already been routed. Changing `request.url` at this point will not re-route the request and will not update `request.pathParameters` or related routing metadata.
@@ -185,7 +185,7 @@ CORS is a security feature that allows web applications to make requests to reso
 
 In Relic you can create a CORS middleware that handles preflight requests and adds CORS headers to the response:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/middleware/cors.dart) doctag="middleware-cors-basic" title="CORS middleware"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/middleware/cors.dart" doctag="middleware-cors-basic" title="CORS middleware"
 
 ## Pipeline (legacy)
 

--- a/doc/site/docs/02-reference/08-static-files.md
+++ b/doc/site/docs/02-reference/08-static-files.md
@@ -10,7 +10,7 @@ Static file serving is essential for web applications that need to deliver asset
 
 To serve static files from a directory, use `StaticHandler.directory()`:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/static_files.dart) doctag="static-files-dir-serve" title="Serve directory with cache"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/static_files.dart" doctag="static-files-dir-serve" title="Serve directory with cache"
 
 **What this code does:**
 
@@ -28,7 +28,7 @@ This serves all files from the `_static_files` directory under `/basic/` URLs wi
 
 For serving individual files, use `StaticHandler.file()`:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/static_files.dart) doctag="static-files-single-file" title="Serve single file"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/static_files.dart" doctag="static-files-single-file" title="Serve single file"
 
 This is useful for specific files like logos, favicons, robots.txt, or other well-known resources.
 
@@ -40,19 +40,19 @@ Effective caching is crucial for static file performance. Relic provides flexibl
 
 For files that might change frequently:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/static_files.dart) doctag="static-files-cache-short" title="Short-term cache control"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/static_files.dart" doctag="static-files-cache-short" title="Short-term cache control"
 
 ### Long-term caching with immutable assets
 
 For assets that never change (like versioned files):
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/static_files.dart) doctag="static-files-cache-long-immutable" title="Long-term immutable caching"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/static_files.dart" doctag="static-files-cache-long-immutable" title="Long-term immutable caching"
 
 ## Cache busting
 
 Cache busting ensures browsers fetch updated files when your assets change. Relic provides built-in cache busting support:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/basic/static_files.dart) doctag="static-files-cache-busting" title="Cache busting config and usage"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/basic/static_files.dart" doctag="static-files-cache-busting" title="Cache busting config and usage"
 
 **How cache busting works:**
 

--- a/doc/site/docs/02-reference/99-pipeline.md
+++ b/doc/site/docs/02-reference/99-pipeline.md
@@ -15,7 +15,7 @@ Pipeline is a legacy pattern for composing middleware, see [Middleware](./middle
 
 The `Pipeline` class is a helper that makes it easy to compose a set of `Middleware` and a `Handler`. It provides a fluent API for building middleware chains that process requests and responses in a specific order.
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/middleware/pipeline.dart) doctag="pipeline-usage" title="Pipeline usage"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/middleware/pipeline.dart" doctag="pipeline-usage" title="Pipeline usage"
 
 ## How Pipeline works
 
@@ -32,11 +32,11 @@ This creates a nested structure where each middleware wraps the next, forming a 
 
 Old Pipeline approach, typically used in Shelf:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/middleware/pipeline.dart) doctag="pipeline-usage" title="Pipeline usage"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/middleware/pipeline.dart" doctag="pipeline-usage" title="Pipeline usage"
 
 New router.use() approach:
 
-GITHUB_CODE_BLOCK lang="dart" [src](https://raw.githubusercontent.com/serverpod/relic/main/example/middleware/pipeline.dart) doctag="router-usage" title="router.use() usage"
+GITHUB_CODE_BLOCK lang="dart" file="../_example/middleware/pipeline.dart" doctag="router-usage" title="router.use() usage"
 
 The new approach is more concise, provides better path-specific middleware control, and integrates more naturally with Relic's routing system.
 


### PR DESCRIPTION
## Description

This PR migrates markdown code block examples to reference local files in the "_example" folder