### PR TITLE
refactor!: Disallow url rewriting in Request.copyWith

### DIFF
--- a/lib/src/context/request.dart
+++ b/lib/src/context/request.dart
@@ -91,10 +91,10 @@ class Request extends Message {
   ///
   /// All parameters are optional. If not provided, the original values are used.
   @override
-  Request copyWith({final Headers? headers, final Uri? url, final Body? body}) {
+  Request copyWith({final Headers? headers, final Body? body}) {
     return Request._(
       method,
-      url ?? this.url,
+      url,
       token,
       headers: headers ?? this.headers,
       protocolVersion: protocolVersion,

--- a/test/src/adapter/context_test.dart
+++ b/test/src/adapter/context_test.dart
@@ -3,7 +3,7 @@ import 'package:relic/src/context/result.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Given a Request, when copyWith is called with a new url,', () {
+  group('Given a Request, when copyWith is called with new headers,', () {
     late Request originalRequest;
     late Request newRequest;
     late Object token;
@@ -15,9 +15,10 @@ void main() {
         Object(),
       );
       token = originalRequest.token;
-      newRequest = originalRequest.copyWith(
-        url: Uri.parse('http://test.com/newpath'),
-      );
+      final newHeaders = Headers.fromMap({
+        'foo': ['bar'],
+      });
+      newRequest = originalRequest.copyWith(headers: newHeaders);
     });
 
     test('then it returns a Request instance', () {
@@ -67,29 +68,32 @@ void main() {
       });
 
       test('then it simplifies middleware request rewriting pattern', () {
-        final rewrittenRequest = originalRequest.copyWith(
-          url: Uri.parse('http://test.com/rewritten'),
-        );
+        final headers = Headers.fromMap({
+          'foo': ['bar'],
+        });
+        final rewrittenRequest = originalRequest.copyWith(headers: headers);
         expect(rewrittenRequest, isA<Request>());
-        expect(rewrittenRequest.url, Uri.parse('http://test.com/rewritten'));
+        expect(rewrittenRequest.headers, headers);
         expect(rewrittenRequest.token, same(token));
       });
 
       test(
         'then it maintains the same token across multiple transformations',
         () {
-          final request1 = originalRequest.copyWith(
-            url: Uri.parse('http://test.com/step1'),
-          );
+          final headers1 = Headers.fromMap({
+            'foo': ['bar'],
+          });
+          final request1 = originalRequest.copyWith(headers: headers1);
 
-          final request2 = request1.copyWith(
-            url: Uri.parse('http://test.com/step2'),
-          );
+          final headers2 = Headers.fromMap({
+            'bar': ['foo'],
+          });
+          final request2 = request1.copyWith(headers: headers2);
 
           expect(originalRequest.token, same(token));
           expect(request1.token, same(token));
           expect(request2.token, same(token));
-          expect(request2.url, Uri.parse('http://test.com/step2'));
+          expect(request2.headers, headers2);
         },
       );
     },


### PR DESCRIPTION
## Description

- Remove `url` parameter from `Request.copyWith()` method
- Update `copyWith` to always use the original URL value
- Update tests to use `headers` parameter instead of `url` for `copyWith` verification

## Related Issues

- Fixes: #276 

## Pre-Launch Checklist

- [x] This update focuses on a single feature or bug fix.
- [x] I have read and followed the Dart Style Guide and formatted the code.
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes

- [x] Includes breaking changes.

The `url` parameter has been removed from `Request.copyWith()`. Callers that previously passed `url` to `copyWith` will need to update their code.
