### PR TITLE
fix: Ensure close is idempotent

### DIFF
--- a/lib/src/relic_server.dart
+++ b/lib/src/relic_server.dart
@@ -228,7 +228,9 @@ final class _MultiIsolateRelicServer implements RelicServer {
 
   @override
   Future<void> close() async {
-    await _children.map((final c) => c.close()).wait;
+    final children = List.of(_children);
+    _children.clear();
+    await children.map((final c) => c.close()).wait;
   }
 
   @override


### PR DESCRIPTION
## Description

- Fix multi-isolate server hanging when `close()` is called multiple times
- Clear `_children` list before closing to make subsequent calls no-ops
- Add tests for sequential and concurrent double-close scenarios
- Refactor test helpers to reduce code duplication

## Related Issues

- Fixes: #293

## Pre-Launch Checklist

- [x] This update focuses on a single feature or bug fix.
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes

- [x] No breaking changes.

## Additional Notes

Investigation confirmed that `HttpServer.close()` and `ServerSocket.close()` are idempotent in dart:io, making the fix safe. The multi-isolate fix uses a synchronous copy-and-clear pattern that acts as a simple mutex for concurrent calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown reliability in RelicServer by safely managing the closure process during concurrent operations.

* **Tests**
  * Added comprehensive test coverage for server shutdown behavior, including in-flight request completion, repeated close calls, and multi-isolate configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->