### PR TITLE
fix: Update curl command example in documentation

### DIFF
--- a/doc/site/docs/01-getting-started/02-hello-world-example.md
+++ b/doc/site/docs/01-getting-started/02-hello-world-example.md
@@ -49,7 +49,7 @@ dart bin/hello_world.dart
 Then, open your browser and visit `http://localhost:8080/user/Nova/age/27`, or use curl:
 
 ```bash
-curl http://localhost:8080/user/Nova/age/37
+curl http://localhost:8080/user/Nova/age/27
 ```
 
 You should see:


### PR DESCRIPTION
## Description
This PR fixes a small inconsistency in the Relic documentation.
The example `curl` command has been updated to use the same URL as shown in the previous step of the guide. This helps keep the documentation consistent and avoids confusion for users following the tutorial step by step.

## Related Issues
* N/A

## Pre-Launch Checklist

- [x] This pull request updates the example curl command in the documentation to match the URL shown in the previous step. This ensures consistency and avoids confusion for users following the tutorial.] This update focuses on a single feature or bug fix. (For multiple fixes, please submit separate PRs.)
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [ ] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation. 
- [ ] I have added new tests to verify the changes.
- [ ] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [ ] Includes breaking changes.
- [x] No breaking changes.

## Additional Notes
This is a documentation-only change and does not affect any runtime behavior or APIs.
