### PR TITLE
chore: Tighten contraints

### DIFF
--- a/packages/benchmark/pubspec.yaml
+++ b/packages/benchmark/pubspec.yaml
@@ -10,9 +10,9 @@ resolution: workspace
 dependencies:
   benchmark_harness: ^2.3.1
   cli_tools: ^0.11.0
-  config: ^0.8.3
+  config: ^0.8.4
   git: ^2.2.1
-  path: ^1.8.4
+  path: ^1.9.0
   relic: ^1.0.0
   routingkit: ^5.1.2
   spanner: ^1.0.5

--- a/packages/relic/pubspec.yaml
+++ b/packages/relic/pubspec.yaml
@@ -23,10 +23,10 @@ dev_dependencies:
   http: ^1.5.0
   http_parser: ^4.0.2
   lints: ^6.0.0
-  meta: ^1.16.0
+  meta: ^1.17.0
   mime: ^2.0.0
   mockito: ^5.4.4
-  path: ^1.8.3
+  path: ^1.9.0
   serverpod_lints: ^3.0.0
   test: ^1.25.10
   test_descriptor: ^2.0.1

--- a/packages/relic_core/pubspec.yaml
+++ b/packages/relic_core/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
   convert: ^3.1.1
   crypto: ^3.0.0
   http_parser: ^4.0.2
-  meta: ^1.16.0
+  meta: ^1.17.0
   mime: ^2.0.0
-  path: ^1.8.3
+  path: ^1.9.0
   stack_trace: ^1.10.0
   stream_channel: ^2.1.1
   vm_service: ^15.0.0

--- a/packages/relic_io/pubspec.yaml
+++ b/packages/relic_io/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 dependencies:
   crypto: ^3.0.0
   mime: ^2.0.0
-  path: ^1.8.3
+  path: ^1.9.0
   relic_core: ^1.0.0
   stack_trace: ^1.10.0
   stream_channel: ^2.1.1


### PR DESCRIPTION
Just tightens constraint to the actual lower bounds, ie. running
```
dart downgrade --tighten
```
using dart 3.8

This does not bump sdk to 3.9 (as I suggested on slack)