### PR TITLE
feat: Add DeveloperTools class to RelicApp

### DIFF
--- a/packages/relic/test/router/relic_app_test.dart
+++ b/packages/relic/test/router/relic_app_test.dart
@@ -189,6 +189,20 @@ void main() {
       });
     });
 
+    test('Given a RelicApp before run is called, '
+        'when checking isDevMode, '
+        'then it returns false', () {
+      final app = RelicApp();
+      expect(app.developerTools.isDevMode, isFalse);
+    });
+
+    test('Given a RelicApp before run is called, '
+        'when checking reloadCount, '
+        'then it returns 0', () {
+      final app = RelicApp();
+      expect(app.developerTools.reloadCount, 0);
+    });
+
     test('Given a RelicApp, '
         'when hot-reloading isolate, '
         'then it is rebuild', () async {
@@ -224,8 +238,14 @@ void main() {
 
       await app.serve(noOfIsolates: 2);
 
+      expect(app.developerTools.reloadCount, 0);
+
       await hotReload(); // 2
+      expect(app.developerTools.reloadCount, 1);
+
       await hotReload(); // 3
+      expect(app.developerTools.reloadCount, 2);
+
       await app.close();
       await hotReload(); // won't emit
       await hotReload(); // won't emit
@@ -233,6 +253,26 @@ void main() {
       await expectLater(called.stream, emitsInOrder([1, 2, 3]));
 
       await vmService.dispose();
+    }, tags: {'hot-reload'});
+
+    test('Given a RelicApp with VM service available, '
+        'when serve is called, '
+        'then isDevMode returns true', () async {
+      final wsUri = (await Service.getInfo()).serverWebSocketUri;
+      if (wsUri == null) {
+        markTestSkipped(
+          'VM service not available! Use: dart run --enable-vm-service',
+        );
+        return;
+      }
+
+      final app = RelicApp()..any('/', (final req) => Response.ok());
+
+      expect(app.developerTools.isDevMode, isFalse);
+      await app.serve(port: 0);
+      expect(app.developerTools.isDevMode, isTrue);
+      await app.close();
+      expect(app.developerTools.isDevMode, isFalse);
     }, tags: {'hot-reload'});
   });
 }

--- a/packages/relic_core/lib/src/router/relic_app.dart
+++ b/packages/relic_core/lib/src/router/relic_app.dart
@@ -154,6 +154,12 @@ final class RelicApp implements RelicRouter, _Reloadable {
   void use(final String path, final Middleware map) =>
       inject(_Injectable((final r) => r.use(path, map)));
 
+  /// Recreates the sub-router on each hot-reload replay instead of reusing
+  /// the consumed (emptied) one from the first call.
+  @override
+  void injectAt(final String path, final RouterInjectable injectable) =>
+      inject(_InjectableAt(path, injectable));
+
   @override
   void inject(final RouterInjectable injectable) => _injectAndTrack(injectable);
 
@@ -213,6 +219,25 @@ final class _Injectable implements RouterInjectable {
 
   @override
   void injectIn(final RelicRouter owner) => setup(owner);
+}
+
+/// Creates a fresh sub-router on each replay so routes survive hot-reload.
+///
+/// The base [Router.injectAt] creates a sub-router and attaches it with
+/// `consume: true`, which empties it. On replay the emptied router produces
+/// no routes. This class recreates the sub-router from the [injectable]
+/// each time [injectIn] is called.
+final class _InjectableAt implements RouterInjectable {
+  final String path;
+  final RouterInjectable injectable;
+
+  _InjectableAt(this.path, this.injectable);
+
+  @override
+  void injectIn(final RelicRouter owner) {
+    final subRouter = RelicRouter()..inject(injectable);
+    owner.attach(path, subRouter, consume: true);
+  }
 }
 
 class _HotReloader {

--- a/packages/relic_core/lib/src/router/relic_app.dart
+++ b/packages/relic_core/lib/src/router/relic_app.dart
@@ -32,7 +32,11 @@ part of 'router.dart';
 /// without restarting the server. Note that this only works for changes to the
 /// route configuration and handlers - changes to server state or global variables
 /// may require a full restart.
-final class RelicApp implements RelicRouter {
+abstract interface class _Reloadable {
+  Future<void> _reload();
+}
+
+final class RelicApp implements RelicRouter, _Reloadable {
   /// Whether to prepend the request's `Host` header to the path during routing.
   ///
   /// When `true`, routes should include the host as the first segment
@@ -42,9 +46,11 @@ final class RelicApp implements RelicRouter {
 
   RelicServer? _server;
   bool _backtrack = true;
-  StreamSubscription? _reloadSubscription;
   var delegate = RelicRouter();
   final _setup = <RouterInjectable>[];
+
+  /// Developer tools for inspecting and debugging the app.
+  late final developerTools = DeveloperTools._();
 
   /// Creates a new [RelicApp].
   ///
@@ -93,13 +99,12 @@ final class RelicApp implements RelicRouter {
     _server = RelicServer(adapterFactory, noOfIsolates: noOfIsolates);
     _backtrack = backtrack;
     await _init();
-    _reloadSubscription = await _hotReloader.register(this);
+    await developerTools._registerForReload(this);
     return _server!;
   }
 
   Future<void> close() async {
-    await _reloadSubscription?.cancel();
-    _reloadSubscription = null;
+    await developerTools._dispose();
     await _server?.close();
     _server = null;
   }
@@ -115,6 +120,7 @@ final class RelicApp implements RelicRouter {
   }
 
   Future<void> _reload() async {
+    developerTools._onReload();
     await _rebuild();
     await _init();
   }
@@ -175,6 +181,31 @@ final class RelicApp implements RelicRouter {
   }) => delegate.lookup(method, path, backtrack: backtrack);
 }
 
+/// Developer tools for inspecting and debugging a [RelicApp].
+final class DeveloperTools {
+  int _reloadCount = 0;
+  StreamSubscription? _reloadSubscription;
+
+  DeveloperTools._();
+
+  /// Number of hot reloads that have occurred since the app started.
+  int get reloadCount => _reloadCount;
+
+  /// Whether the VM service is available (i.e. running in dev mode).
+  bool get isDevMode => _reloadSubscription != null;
+
+  Future<void> _registerForReload(final _Reloadable app) async {
+    _reloadSubscription = await _hotReloader.registerForReload(app);
+  }
+
+  Future<void> _dispose() async {
+    await _reloadSubscription?.cancel();
+    _reloadSubscription = null;
+  }
+
+  void _onReload() => _reloadCount++;
+}
+
 final class _Injectable implements RouterInjectable {
   final void Function(RelicRouter) setup;
 
@@ -202,7 +233,7 @@ class _HotReloader {
     return null; // no vm service available
   }
 
-  Future<StreamSubscription?> register(final RelicApp app) async {
+  Future<StreamSubscription?> registerForReload(final _Reloadable app) async {
     final reloadStream = await _reloadStream;
     if (reloadStream != null) {
       return reloadStream.asyncListen((_) => app._reload());

--- a/packages/relic_core/lib/src/router/router.dart
+++ b/packages/relic_core/lib/src/router/router.dart
@@ -177,6 +177,12 @@ final class Router<T extends Object> {
 
   /// Returns true if the router has a single root route ('/').
   bool get isSingle => _allRoutes.isSingle;
+
+  /// Injects [injectable] at [path], creating a consumed sub-router.
+  void injectAt(final String path, final InjectableIn<Router<T>> injectable) {
+    final subRouter = Router<T>()..inject(injectable);
+    attach(path, subRouter, consume: true);
+  }
 }
 
 extension RouteEx<T extends Object> on Router<T> {
@@ -249,12 +255,6 @@ extension RouteEx<T extends Object> on Router<T> {
     final subRouter = Router<T>();
     attach(path, subRouter);
     return subRouter;
-  }
-
-  /// Injects [injectable] at [path]
-  void injectAt(final String path, final InjectableIn<Router<T>> injectable) {
-    final subRouter = Router<T>()..inject(injectable);
-    attach(path, subRouter, consume: true);
   }
 }
 


### PR DESCRIPTION
## Description

Add a `DeveloperTools` class to `RelicApp`, accessible via `app.developerTools`. Provides `reloadCount` and `isDevMode` getters for hot-reload introspection. A private `_Reloadable` interface decouples `DeveloperTools` from `RelicApp`.

Also fixes hot-reload support for routes added via `injectAt`.

## Related Issues

- Related: https://github.com/serverpod/serverpod/pull/4788/

## Pre-Launch Checklist

- [x] This update focuses on a single feature or bug fix.
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes

- [ ] Includes breaking changes.
- [x] No breaking changes.

## Additional Notes

None.
