### PR TITLE
feat: Add staticChangeCount and VM service extension to DeveloperTools

### DIFF
--- a/packages/relic/test/router/relic_app_test.dart
+++ b/packages/relic/test/router/relic_app_test.dart
@@ -255,6 +255,48 @@ void main() {
       await vmService.dispose();
     }, tags: {'hot-reload'});
 
+    test('Given a RelicApp before run is called, '
+        'when checking staticChangeCount, '
+        'then it returns 0', () {
+      final app = RelicApp();
+      expect(app.developerTools.staticChangeCount, 0);
+    });
+
+    test('Given a running RelicApp with VM service available, '
+        'when notifyStaticChange is called, '
+        'then staticChangeCount increments', () async {
+      final wsUri = (await Service.getInfo()).serverWebSocketUri;
+      if (wsUri == null) {
+        markTestSkipped(
+          'VM service not available! Use: dart run --enable-vm-service',
+        );
+        return;
+      }
+
+      final vmService = await vmi.vmServiceConnectUri(wsUri.toString());
+      final isolateId = Service.getIsolateId(Isolate.current)!;
+      final app = RelicApp()..any('/', (final req) => Response.ok());
+
+      await app.serve(port: 0);
+
+      expect(app.developerTools.staticChangeCount, 0);
+
+      await vmService.callServiceExtension(
+        'ext.relic.notifyStaticChange',
+        isolateId: isolateId,
+      );
+      expect(app.developerTools.staticChangeCount, 1);
+
+      await vmService.callServiceExtension(
+        'ext.relic.notifyStaticChange',
+        isolateId: isolateId,
+      );
+      expect(app.developerTools.staticChangeCount, 2);
+
+      await app.close();
+      await vmService.dispose();
+    }, tags: {'hot-reload'});
+
     test('Given a RelicApp with VM service available, '
         'when serve is called, '
         'then isDevMode returns true', () async {

--- a/packages/relic_core/lib/src/router/relic_app.dart
+++ b/packages/relic_core/lib/src/router/relic_app.dart
@@ -190,6 +190,7 @@ final class RelicApp implements RelicRouter, _Reloadable {
 /// Developer tools for inspecting and debugging a [RelicApp].
 final class DeveloperTools {
   int _reloadCount = 0;
+  int _staticChangeCount = 0;
   StreamSubscription? _reloadSubscription;
 
   DeveloperTools._();
@@ -197,20 +198,45 @@ final class DeveloperTools {
   /// Number of hot reloads that have occurred since the app started.
   int get reloadCount => _reloadCount;
 
+  /// Number of static file changes that have been notified since the app
+  /// started. This is incremented by external tools (e.g. the CLI) via the
+  /// `ext.relic.notifyStaticChange` VM service extension.
+  int get staticChangeCount => _staticChangeCount;
+
   /// Whether the VM service is available (i.e. running in dev mode).
   bool get isDevMode => _reloadSubscription != null;
 
   Future<void> _registerForReload(final _Reloadable app) async {
     _reloadSubscription = await _hotReloader.registerForReload(app);
+    if (_reloadSubscription != null) {
+      _registerStaticChangeExtension();
+    }
   }
 
   Future<void> _dispose() async {
+    _staticChangeInstances.remove(this);
     await _reloadSubscription?.cancel();
     _reloadSubscription = null;
   }
 
   void _onReload() => _reloadCount++;
+
+  void _registerStaticChangeExtension() {
+    _staticChangeInstances.add(this);
+    if (!_staticChangeExtensionRegistered) {
+      _staticChangeExtensionRegistered = true;
+      registerExtension('ext.relic.notifyStaticChange', (method, params) async {
+        for (final instance in _staticChangeInstances) {
+          instance._staticChangeCount++;
+        }
+        return ServiceExtensionResponse.result('{"type":"Success"}');
+      });
+    }
+  }
 }
+
+bool _staticChangeExtensionRegistered = false;
+final _staticChangeInstances = <DeveloperTools>{};
 
 final class _Injectable implements RouterInjectable {
   final void Function(RelicRouter) setup;


### PR DESCRIPTION
## Description

Add `staticChangeCount` getter and `ext.relic.notifyStaticChange` VM service extension to `DeveloperTools`. External tools (e.g. the `serverpod start --watch` comand) can call the extension to notify the app of static file changes. 

## Related Issues

- Related: https://github.com/serverpod/serverpod/issues/4773

## Pre-Launch Checklist

- [x] This update focuses on a single feature or bug fix.
- [x] I have read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code using [dart format](https://dart.dev/tools/dart-format).
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`), ensuring consistency with existing project documentation.
- [ ] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [ ] I have documented any breaking changes below.

## Breaking Changes

- [ ] Includes breaking changes.
- [x] No breaking changes.

## Additional Notes

None.
