### PR TITLE
refactor: Cookie and Set-Cookie header

### DIFF
--- a/packages/relic/test/headers/header_test.dart
+++ b/packages/relic/test/headers/header_test.dart
@@ -837,7 +837,9 @@ void main() {
       (Headers.server, (final h) => h.server = 'localhost'),
       (
         Headers.setCookie,
-        (final h) => h.setCookie = SetCookieHeader(name: 'foo', value: 'bar'),
+        (final h) => h.setCookie = SetCookieHeader([
+          SetCookie(name: 'foo', value: 'bar'),
+        ]),
       ),
       (
         Headers.strictTransportSecurity,

--- a/packages/relic/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic/test/headers/typed/cookie_header_test.dart
@@ -135,8 +135,8 @@ void main() {
       },
     );
 
-    test('when a valid Cookie header is passed with an empty name '
-        'then it should parse the cookies correctly', () async {
+    test('when a Cookie header carries a nameless `=value` segment '
+        'then it is dropped and the named cookies are kept', () async {
       final headers = await getServerRequestHeaders(
         server: server,
         touchHeaders: (final h) => h.cookie,
@@ -145,11 +145,11 @@ void main() {
 
       expect(
         headers.cookie?.cookies.map((final c) => c.name).toList(),
-        equals(['', 'userId']),
+        equals(['userId']),
       );
       expect(
         headers.cookie?.cookies.map((final c) => c.value).toList(),
-        equals(['abc123', '42']),
+        equals(['42']),
       );
     });
 

--- a/packages/relic/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic/test/headers/typed/cookie_header_test.dart
@@ -36,20 +36,85 @@ void main() {
     );
 
     test(
-      'when a Cookie header with invalid format is passed then the server responds '
-      'with a bad request including a message that states the cookie format is invalid',
+      'when a cookie with an invalid format (no "=") is present '
+      'then it is skipped and the remaining valid cookies are still parsed',
+      () async {
+        // A single malformed cookie must not make the other cookies in the
+        // same header unreadable.
+        final headers = await getServerRequestHeaders(
+          server: server,
+          touchHeaders: (final h) => h.cookie,
+          headers: {'cookie': 'sessionId=abc123; invalidCookie'},
+        );
+
+        expect(
+          headers.cookie?.cookies.map((final c) => c.name).toList(),
+          equals(['sessionId']),
+        );
+        expect(
+          headers.cookie?.cookies.map((final c) => c.value).toList(),
+          equals(['abc123']),
+        );
+      },
+    );
+
+    test(
+      'when a cookie with an invalid name is present '
+      'then it is skipped and the remaining valid cookies are still parsed',
+      () async {
+        final headers = await getServerRequestHeaders(
+          server: server,
+          touchHeaders: (final h) => h.cookie,
+          headers: {'cookie': 'invalid name=abc123; userId=42'},
+        );
+
+        expect(
+          headers.cookie?.cookies.map((final c) => c.name).toList(),
+          equals(['userId']),
+        );
+        expect(
+          headers.cookie?.cookies.map((final c) => c.value).toList(),
+          equals(['42']),
+        );
+      },
+    );
+
+    test(
+      'when a cookie with an invalid value is present '
+      'then it is skipped and the remaining valid cookies are still parsed',
+      () async {
+        final headers = await getServerRequestHeaders(
+          server: server,
+          touchHeaders: (final h) => h.cookie,
+          headers: {'cookie': 'sessionId=abc123; userId=42\x7F'},
+        );
+
+        expect(
+          headers.cookie?.cookies.map((final c) => c.name).toList(),
+          equals(['sessionId']),
+        );
+        expect(
+          headers.cookie?.cookies.map((final c) => c.value).toList(),
+          equals(['abc123']),
+        );
+      },
+    );
+
+    test(
+      'when every cookie in the header is invalid '
+      'then the server responds with a bad request stating there are no valid cookies',
       () async {
         expect(
           getServerRequestHeaders(
             server: server,
             touchHeaders: (final h) => h.cookie,
-            headers: {'cookie': 'sessionId=abc123; invalidCookie'},
+            headers: {'cookie': 'invalidCookie; another invalid'},
           ),
           throwsA(
             isA<BadRequestException>().having(
               (final e) => e.message,
               'message',
-              contains('Invalid cookie format'),
+              contains('No valid cookies in Cookie header'),
             ),
           ),
         );
@@ -57,146 +122,97 @@ void main() {
     );
 
     test(
-      'when a Cookie header with an invalid name is passed then the server responds '
-      'with a bad request including a message that states the cookie name is invalid',
+      'when a Cookie header with an invalid value is passed '
+      'then the server does not respond with a bad request if the headers is not actually used',
       () async {
-        expect(
-          getServerRequestHeaders(
-            server: server,
-            touchHeaders: (final h) => h.cookie,
-            headers: {'cookie': 'invalid name=abc123; userId=42'},
-          ),
-          throwsA(
-            isA<BadRequestException>().having(
-              (final e) => e.message,
-              'message',
-              contains('Invalid cookie name'),
-            ),
-          ),
+        final headers = await getServerRequestHeaders(
+          server: server,
+          touchHeaders: (_) {},
+          headers: {'cookie': 'sessionId=abc123; userId=42\x7F'},
         );
+
+        expect(headers, isNotNull);
       },
     );
 
-    test(
-      'when a Cookie header with an invalid value is passed then the server responds '
-      'with a bad request including a message that states the cookie value is invalid',
-      () async {
-        expect(
-          getServerRequestHeaders(
-            server: server,
-            touchHeaders: (final h) => h.cookie,
-            headers: {'cookie': 'sessionId=abc123; userId=42\x7F'},
-          ),
-          throwsA(
-            isA<BadRequestException>().having(
-              (final e) => e.message,
-              'message',
-              contains('Invalid cookie value'),
-            ),
-          ),
-        );
-      },
-    );
-
-    test('when a Cookie header with an invalid value is passed '
-        'then the server does not respond with a bad request if the headers '
-        'is not actually used', () async {
+    test('when a valid Cookie header is passed with an empty name '
+        'then it should parse the cookies correctly', () async {
       final headers = await getServerRequestHeaders(
         server: server,
-        touchHeaders: (_) {},
-        headers: {'cookie': 'sessionId=abc123; userId=42\x7F'},
+        touchHeaders: (final h) => h.cookie,
+        headers: {'cookie': '=abc123; userId=42'},
       );
 
-      expect(headers, isNotNull);
+      expect(
+        headers.cookie?.cookies.map((final c) => c.name).toList(),
+        equals(['', 'userId']),
+      );
+      expect(
+        headers.cookie?.cookies.map((final c) => c.value).toList(),
+        equals(['abc123', '42']),
+      );
+    });
+
+    test('when a valid Cookie header is passed '
+        'then it should parse the cookies correctly', () async {
+      final headers = await getServerRequestHeaders(
+        server: server,
+        touchHeaders: (final h) => h.cookie,
+        headers: {'cookie': 'sessionId=abc123; userId=42'},
+      );
+
+      expect(
+        headers.cookie?.cookies.map((final c) => c.name).toList(),
+        equals(['sessionId', 'userId']),
+      );
+      expect(
+        headers.cookie?.cookies.map((final c) => c.value).toList(),
+        equals(['abc123', '42']),
+      );
+    });
+
+    test('when a Cookie header with encoded characters in the value is passed '
+        'then it should parse correctly', () async {
+      // Cookie values are opaque octets per RFC 6265; percent encoding is
+      // an application-level convention and MUST NOT be decoded by the
+      // server. The raw bytes round-trip through the parser unchanged.
+      final headers = await getServerRequestHeaders(
+        server: server,
+        touchHeaders: (final h) => h.cookie,
+        headers: {'cookie': 'sessionId=abc%20123; userId=42'},
+      );
+
+      expect(
+        headers.cookie?.cookies.map((final c) => c.name).toList(),
+        equals(['sessionId', 'userId']),
+      );
+      expect(
+        headers.cookie?.cookies.map((final c) => c.value).toList(),
+        equals(['abc%20123', '42']),
+      );
+    });
+
+    test('when a valid Cookie header with duplicate cookies is passed '
+        'then it should parse correctly and remove the duplicates', () async {
+      final headers = await getServerRequestHeaders(
+        server: server,
+        touchHeaders: (final h) => h.cookie,
+        headers: {'cookie': 'sessionId=abc123; userId=42; sessionId=abc123'},
+      );
+
+      expect(
+        headers.cookie?.cookies.map((final c) => c.name).toList(),
+        equals(['sessionId', 'userId']),
+      );
+      expect(
+        headers.cookie?.cookies.map((final c) => c.value).toList(),
+        equals(['abc123', '42']),
+      );
     });
 
     test(
-      'when a valid Cookie header is passed with an empty name then it should parse the cookies correctly',
-      () async {
-        final headers = await getServerRequestHeaders(
-          server: server,
-          touchHeaders: (final h) => h.cookie,
-          headers: {'cookie': '=abc123; userId=42'},
-        );
-
-        expect(
-          headers.cookie?.cookies.map((final c) => c.name).toList(),
-          equals(['', 'userId']),
-        );
-        expect(
-          headers.cookie?.cookies.map((final c) => c.value).toList(),
-          equals(['abc123', '42']),
-        );
-      },
-    );
-
-    test(
-      'when a valid Cookie header is passed then it should parse the cookies correctly',
-      () async {
-        final headers = await getServerRequestHeaders(
-          server: server,
-          touchHeaders: (final h) => h.cookie,
-          headers: {'cookie': 'sessionId=abc123; userId=42'},
-        );
-
-        expect(
-          headers.cookie?.cookies.map((final c) => c.name).toList(),
-          equals(['sessionId', 'userId']),
-        );
-        expect(
-          headers.cookie?.cookies.map((final c) => c.value).toList(),
-          equals(['abc123', '42']),
-        );
-      },
-    );
-
-    test(
-      'when a Cookie header with encoded characters in the value is passed then it should parse correctly',
-      () async {
-        // Cookie values are opaque octets per RFC 6265; percent encoding is
-        // an application-level convention and MUST NOT be decoded by the
-        // server. The raw bytes round-trip through the parser unchanged.
-        final headers = await getServerRequestHeaders(
-          server: server,
-          touchHeaders: (final h) => h.cookie,
-          headers: {'cookie': 'sessionId=abc%20123; userId=42'},
-        );
-
-        expect(
-          headers.cookie?.cookies.map((final c) => c.name).toList(),
-          equals(['sessionId', 'userId']),
-        );
-        expect(
-          headers.cookie?.cookies.map((final c) => c.value).toList(),
-          equals(['abc%20123', '42']),
-        );
-      },
-    );
-
-    test(
-      'when a valid Cookie header with duplicate cookies is passed then it should '
-      'parse the cookies correctly and remove the duplicates',
-      () async {
-        final headers = await getServerRequestHeaders(
-          server: server,
-          touchHeaders: (final h) => h.cookie,
-          headers: {'cookie': 'sessionId=abc123; userId=42; sessionId=abc123'},
-        );
-
-        expect(
-          headers.cookie?.cookies.map((final c) => c.name).toList(),
-          equals(['sessionId', 'userId']),
-        );
-        expect(
-          headers.cookie?.cookies.map((final c) => c.value).toList(),
-          equals(['abc123', '42']),
-        );
-      },
-    );
-
-    test(
-      'when a Cookie header has two cookies with the same name but different '
-      'values then both are preserved and getCookie returns the first',
+      'when a Cookie header has two cookies with the same name but different values '
+      'then both are preserved and getCookie returns the first',
       () async {
         // RFC 6265 5.4 allows a Cookie header to carry duplicate cookie names
         // (e.g. a host-only cookie plus a Domain-scoped one); the server cannot
@@ -220,25 +236,23 @@ void main() {
       },
     );
 
-    test(
-      'when a Cookie header is passed with extra whitespace then it should parse the cookies correctly',
-      () async {
-        final headers = await getServerRequestHeaders(
-          server: server,
-          touchHeaders: (final h) => h.cookie,
-          headers: {'cookie': ' sessionId=abc123 ; userId=42 '},
-        );
+    test('when a Cookie header is passed with extra whitespace '
+        'then it should parse the cookies correctly', () async {
+      final headers = await getServerRequestHeaders(
+        server: server,
+        touchHeaders: (final h) => h.cookie,
+        headers: {'cookie': ' sessionId=abc123 ; userId=42 '},
+      );
 
-        expect(
-          headers.cookie?.cookies.map((final c) => c.name).toList(),
-          equals(['sessionId', 'userId']),
-        );
-        expect(
-          headers.cookie?.cookies.map((final c) => c.value).toList(),
-          equals(['abc123', '42']),
-        );
-      },
-    );
+      expect(
+        headers.cookie?.cookies.map((final c) => c.name).toList(),
+        equals(['sessionId', 'userId']),
+      );
+      expect(
+        headers.cookie?.cookies.map((final c) => c.value).toList(),
+        equals(['abc123', '42']),
+      );
+    });
   });
 
   group('Given a Cookie header without validation', () {
@@ -250,20 +264,21 @@ void main() {
 
     tearDown(() => server.close());
 
-    group('when parsing an invalid cookie header', () {
-      test(
-        'when an invalid Cookie header is passed then it should return null',
-        () async {
-          final headers = await getServerRequestHeaders(
-            server: server,
-            touchHeaders: (_) {},
-            headers: {'cookie': 'sessionId=abc123; invalidCookie'},
-          );
+    group('when parsing a fully invalid cookie header', () {
+      test('when no cookie in the header is valid '
+          'then it should return null', () async {
+        // Only a header with no usable cookie at all is invalid; a header
+        // with at least one valid cookie parses (the invalid ones are
+        // skipped), so use an entirely invalid header here.
+        final headers = await getServerRequestHeaders(
+          server: server,
+          touchHeaders: (_) {},
+          headers: {'cookie': 'invalidCookie; another invalid'},
+        );
 
-          expect(Headers.cookie[headers].valueOrNullIfInvalid, isNull);
-          expect(() => headers.cookie, throwsInvalidHeader);
-        },
-      );
+        expect(Headers.cookie[headers].valueOrNullIfInvalid, isNull);
+        expect(() => headers.cookie, throwsInvalidHeader);
+      });
     });
   });
 }

--- a/packages/relic/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic/test/headers/typed/cookie_header_test.dart
@@ -5,18 +5,18 @@ import '../headers_test_utils.dart';
 
 /// Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie
 void main() {
-  group('Given a Cookie header with validation', () {
-    late RelicServer server;
+  late RelicServer server;
 
-    setUp(() async {
-      server = await createServer();
-    });
+  setUp(() async {
+    server = await createServer();
+  });
 
-    tearDown(() => server.close());
+  tearDown(() => server.close());
 
+  group('Given an empty Cookie header,', () {
     test(
-      'when an empty Cookie header is passed then the server responds '
-      'with a bad request including a message that states the header value cannot be empty',
+      'when it is accessed '
+      'then the server responds with a bad request stating the value cannot be empty',
       () async {
         expect(
           getServerRequestHeaders(
@@ -34,10 +34,12 @@ void main() {
         );
       },
     );
+  });
 
+  group('Given a Cookie header with a malformed-format cookie (no "="),', () {
     test(
-      'when a cookie with an invalid format (no "=") is present '
-      'then it is skipped and the remaining valid cookies are still parsed',
+      'when it is accessed '
+      'then the malformed cookie is skipped and the valid cookies remain',
       () async {
         // A single malformed cookie must not make the other cookies in the
         // same header unreadable.
@@ -57,10 +59,12 @@ void main() {
         );
       },
     );
+  });
 
+  group('Given a Cookie header with an invalid cookie name,', () {
     test(
-      'when a cookie with an invalid name is present '
-      'then it is skipped and the remaining valid cookies are still parsed',
+      'when it is accessed '
+      'then the invalid cookie is skipped and the valid cookies remain',
       () async {
         final headers = await getServerRequestHeaders(
           server: server,
@@ -78,10 +82,12 @@ void main() {
         );
       },
     );
+  });
 
+  group('Given a Cookie header with an invalid cookie value,', () {
     test(
-      'when a cookie with an invalid value is present '
-      'then it is skipped and the remaining valid cookies are still parsed',
+      'when it is accessed '
+      'then the invalid cookie is skipped and the valid cookies remain',
       () async {
         final headers = await getServerRequestHeaders(
           server: server,
@@ -99,9 +105,11 @@ void main() {
         );
       },
     );
+  });
 
+  group('Given a Cookie header where every cookie is invalid,', () {
     test(
-      'when every cookie in the header is invalid '
+      'when it is accessed '
       'then the server responds with a bad request stating there are no valid cookies',
       () async {
         expect(
@@ -122,39 +130,51 @@ void main() {
     );
 
     test(
-      'when a Cookie header with an invalid value is passed '
-      'then the server does not respond with a bad request if the headers is not actually used',
+      'when it is not accessed '
+      'then no error is raised (the header is parsed lazily) and the tolerant accessor yields null',
       () async {
+        // Parsing is lazy: an untouched header raises nothing, even when every
+        // cookie in it is invalid. The tolerant accessor yields null and a
+        // direct access throws.
         final headers = await getServerRequestHeaders(
           server: server,
           touchHeaders: (_) {},
-          headers: {'cookie': 'sessionId=abc123; userId=42\x7F'},
+          headers: {'cookie': 'invalidCookie; another invalid'},
         );
 
         expect(headers, isNotNull);
+        expect(Headers.cookie[headers].valueOrNullIfInvalid, isNull);
+        expect(() => headers.cookie, throwsInvalidHeader);
       },
     );
+  });
 
-    test('when a Cookie header carries a nameless `=value` segment '
-        'then it is dropped and the named cookies are kept', () async {
-      final headers = await getServerRequestHeaders(
-        server: server,
-        touchHeaders: (final h) => h.cookie,
-        headers: {'cookie': '=abc123; userId=42'},
-      );
+  group('Given a Cookie header with a nameless `=value` segment,', () {
+    test(
+      'when it is accessed '
+      'then the nameless segment is dropped and the named cookies are kept',
+      () async {
+        final headers = await getServerRequestHeaders(
+          server: server,
+          touchHeaders: (final h) => h.cookie,
+          headers: {'cookie': '=abc123; userId=42'},
+        );
 
-      expect(
-        headers.cookie?.cookies.map((final c) => c.name).toList(),
-        equals(['userId']),
-      );
-      expect(
-        headers.cookie?.cookies.map((final c) => c.value).toList(),
-        equals(['42']),
-      );
-    });
+        expect(
+          headers.cookie?.cookies.map((final c) => c.name).toList(),
+          equals(['userId']),
+        );
+        expect(
+          headers.cookie?.cookies.map((final c) => c.value).toList(),
+          equals(['42']),
+        );
+      },
+    );
+  });
 
-    test('when a valid Cookie header is passed '
-        'then it should parse the cookies correctly', () async {
+  group('Given a valid Cookie header,', () {
+    test('when it is accessed '
+        'then the cookies are parsed in order', () async {
       final headers = await getServerRequestHeaders(
         server: server,
         touchHeaders: (final h) => h.cookie,
@@ -170,30 +190,40 @@ void main() {
         equals(['abc123', '42']),
       );
     });
+  });
 
-    test('when a Cookie header with encoded characters in the value is passed '
-        'then it should parse correctly', () async {
-      // Cookie values are opaque octets per RFC 6265; percent encoding is
-      // an application-level convention and MUST NOT be decoded by the
-      // server. The raw bytes round-trip through the parser unchanged.
-      final headers = await getServerRequestHeaders(
-        server: server,
-        touchHeaders: (final h) => h.cookie,
-        headers: {'cookie': 'sessionId=abc%20123; userId=42'},
-      );
+  group(
+    'Given a Cookie header with percent-encoded characters in the value,',
+    () {
+      test(
+        'when it is accessed '
+        'then the raw bytes round-trip unchanged (no percent-decoding)',
+        () async {
+          // Cookie values are opaque octets per RFC 6265; percent encoding is
+          // an application-level convention and MUST NOT be decoded by the
+          // server. The raw bytes round-trip through the parser unchanged.
+          final headers = await getServerRequestHeaders(
+            server: server,
+            touchHeaders: (final h) => h.cookie,
+            headers: {'cookie': 'sessionId=abc%20123; userId=42'},
+          );
 
-      expect(
-        headers.cookie?.cookies.map((final c) => c.name).toList(),
-        equals(['sessionId', 'userId']),
+          expect(
+            headers.cookie?.cookies.map((final c) => c.name).toList(),
+            equals(['sessionId', 'userId']),
+          );
+          expect(
+            headers.cookie?.cookies.map((final c) => c.value).toList(),
+            equals(['abc%20123', '42']),
+          );
+        },
       );
-      expect(
-        headers.cookie?.cookies.map((final c) => c.value).toList(),
-        equals(['abc%20123', '42']),
-      );
-    });
+    },
+  );
 
+  group('Given a Cookie header with byte-identical duplicate cookies,', () {
     test(
-      'when a valid Cookie header with byte-identical duplicate cookies is passed '
+      'when it is accessed '
       'then every cookie is preserved (duplicates are not collapsed)',
       () async {
         // RFC 6265 5.4 permits repeated cookies; the server cannot distinguish
@@ -215,11 +245,13 @@ void main() {
         );
       },
     );
+  });
 
-    test(
-      'when a Cookie header has two cookies with the same name but different values '
-      'then both are preserved and getCookie returns the first',
-      () async {
+  group(
+    'Given a Cookie header with same-name cookies of different values,',
+    () {
+      test('when it is accessed '
+          'then both are preserved and getCookie returns the first', () async {
         // RFC 6265 5.4 allows a Cookie header to carry duplicate cookie names
         // (e.g. a host-only cookie plus a Domain-scoped one); the server cannot
         // distinguish them from the header alone. The header must still parse,
@@ -239,11 +271,13 @@ void main() {
           equals(['abc123', 'xyz789']),
         );
         expect(headers.cookie?.getCookie('sessionId')?.value, equals('abc123'));
-      },
-    );
+      });
+    },
+  );
 
-    test('when a Cookie header is passed with extra whitespace '
-        'then it should parse the cookies correctly', () async {
+  group('Given a Cookie header with extra whitespace,', () {
+    test('when it is accessed '
+        'then the surrounding whitespace is trimmed', () async {
       final headers = await getServerRequestHeaders(
         server: server,
         touchHeaders: (final h) => h.cookie,
@@ -258,33 +292,6 @@ void main() {
         headers.cookie?.cookies.map((final c) => c.value).toList(),
         equals(['abc123', '42']),
       );
-    });
-  });
-
-  group('Given a Cookie header without validation', () {
-    late RelicServer server;
-
-    setUp(() async {
-      server = await createServer();
-    });
-
-    tearDown(() => server.close());
-
-    group('when parsing a fully invalid cookie header', () {
-      test('when no cookie in the header is valid '
-          'then it should return null', () async {
-        // Only a header with no usable cookie at all is invalid; a header
-        // with at least one valid cookie parses (the invalid ones are
-        // skipped), so use an entirely invalid header here.
-        final headers = await getServerRequestHeaders(
-          server: server,
-          touchHeaders: (_) {},
-          headers: {'cookie': 'invalidCookie; another invalid'},
-        );
-
-        expect(Headers.cookie[headers].valueOrNullIfInvalid, isNull);
-        expect(() => headers.cookie, throwsInvalidHeader);
-      });
     });
   });
 }

--- a/packages/relic/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic/test/headers/typed/cookie_header_test.dart
@@ -192,23 +192,29 @@ void main() {
       );
     });
 
-    test('when a valid Cookie header with duplicate cookies is passed '
-        'then it should parse correctly and remove the duplicates', () async {
-      final headers = await getServerRequestHeaders(
-        server: server,
-        touchHeaders: (final h) => h.cookie,
-        headers: {'cookie': 'sessionId=abc123; userId=42; sessionId=abc123'},
-      );
+    test(
+      'when a valid Cookie header with byte-identical duplicate cookies is passed '
+      'then every cookie is preserved (duplicates are not collapsed)',
+      () async {
+        // RFC 6265 5.4 permits repeated cookies; the server cannot distinguish
+        // them from the header alone, so getCookies must report the true count
+        // rather than silently deduping byte-identical segments.
+        final headers = await getServerRequestHeaders(
+          server: server,
+          touchHeaders: (final h) => h.cookie,
+          headers: {'cookie': 'sessionId=abc123; userId=42; sessionId=abc123'},
+        );
 
-      expect(
-        headers.cookie?.cookies.map((final c) => c.name).toList(),
-        equals(['sessionId', 'userId']),
-      );
-      expect(
-        headers.cookie?.cookies.map((final c) => c.value).toList(),
-        equals(['abc123', '42']),
-      );
-    });
+        expect(
+          headers.cookie?.cookies.map((final c) => c.name).toList(),
+          equals(['sessionId', 'userId', 'sessionId']),
+        );
+        expect(
+          headers.cookie?.cookies.map((final c) => c.value).toList(),
+          equals(['abc123', '42', 'abc123']),
+        );
+      },
+    );
 
     test(
       'when a Cookie header has two cookies with the same name but different values '

--- a/packages/relic/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic/test/headers/typed/set_cookie_header_test.dart
@@ -91,8 +91,8 @@ void main() {
           headers: {'set-cookie': 'sessionId=test; userId=42'},
         );
 
-        expect(headers.setCookie?.name, equals('sessionId'));
-        expect(headers.setCookie?.value, equals('test'));
+        expect(headers.setCookie?.cookies.single.name, equals('sessionId'));
+        expect(headers.setCookie?.cookies.single.value, equals('test'));
       },
     );
 
@@ -104,8 +104,8 @@ void main() {
         headers: {'set-cookie': 'sessionId=abc123; invalidCookie'},
       );
 
-      expect(headers.setCookie?.name, equals('sessionId'));
-      expect(headers.setCookie?.value, equals('abc123'));
+      expect(headers.setCookie?.cookies.single.name, equals('sessionId'));
+      expect(headers.setCookie?.cookies.single.value, equals('abc123'));
     });
 
     test(
@@ -171,8 +171,8 @@ void main() {
           headers: {'set-cookie': '=abc123'},
         );
 
-        expect(headers.setCookie?.name, isEmpty);
-        expect(headers.setCookie?.value, equals('abc123'));
+        expect(headers.setCookie?.cookies.single.name, isEmpty);
+        expect(headers.setCookie?.cookies.single.value, equals('abc123'));
       },
     );
 
@@ -188,15 +188,21 @@ void main() {
           },
         );
 
-        expect(headers.setCookie?.name, equals('sessionId'));
-        expect(headers.setCookie?.value, equals('abc123'));
-        expect(headers.setCookie?.expires, isNotNull);
-        expect(headers.setCookie?.maxAge, equals(3600));
-        expect(headers.setCookie?.domain.toString(), equals('example.com'));
-        expect(headers.setCookie?.path.toString(), equals('/'));
-        expect(headers.setCookie?.secure, isTrue);
-        expect(headers.setCookie?.httpOnly, isTrue);
-        expect(headers.setCookie?.sameSite?.name, equals(SameSite.strict.name));
+        expect(headers.setCookie?.cookies.single.name, equals('sessionId'));
+        expect(headers.setCookie?.cookies.single.value, equals('abc123'));
+        expect(headers.setCookie?.cookies.single.expires, isNotNull);
+        expect(headers.setCookie?.cookies.single.maxAge, equals(3600));
+        expect(
+          headers.setCookie?.cookies.single.domain.toString(),
+          equals('example.com'),
+        );
+        expect(headers.setCookie?.cookies.single.path.toString(), equals('/'));
+        expect(headers.setCookie?.cookies.single.secure, isTrue);
+        expect(headers.setCookie?.cookies.single.httpOnly, isTrue);
+        expect(
+          headers.setCookie?.cookies.single.sameSite?.name,
+          equals(SameSite.strict.name),
+        );
       },
     );
 
@@ -209,9 +215,9 @@ void main() {
           headers: {'set-cookie': ' sessionId=abc123 ; Secure '},
         );
 
-        expect(headers.setCookie?.name, equals('sessionId'));
-        expect(headers.setCookie?.value, equals('abc123'));
-        expect(headers.setCookie?.secure, isTrue);
+        expect(headers.setCookie?.cookies.single.name, equals('sessionId'));
+        expect(headers.setCookie?.cookies.single.value, equals('abc123'));
+        expect(headers.setCookie?.cookies.single.secure, isTrue);
       },
     );
   });
@@ -238,8 +244,8 @@ void main() {
               headers: {'set-cookie': 'sessionId=abc123; invalidCookie'},
             );
 
-            expect(headers.setCookie?.name, equals('sessionId'));
-            expect(headers.setCookie?.value, equals('abc123'));
+            expect(headers.setCookie?.cookies.single.name, equals('sessionId'));
+            expect(headers.setCookie?.cookies.single.value, equals('abc123'));
           },
         );
       },

--- a/packages/relic_core/lib/src/headers/extension/string_list_extensions.dart
+++ b/packages/relic_core/lib/src/headers/extension/string_list_extensions.dart
@@ -17,16 +17,22 @@ extension StringListExtensions on Iterable<String> {
   Iterable<String> splitTrimAndFilterUnique({
     final String separator = ',',
     final bool emptyCheck = true,
+    final bool noTrim = false,
   }) => LinkedHashSet<String>.from(
-    splitAndTrim(separator: separator, emptyCheck: emptyCheck),
+    splitAndTrim(separator: separator, emptyCheck: emptyCheck, noTrim: noTrim),
   );
 
   Iterable<String> splitAndTrim({
     final String separator = ',',
     final bool emptyCheck = true,
-  }) => expand((final element) => element.split(separator))
-      .map((final el) => el.trim())
-      .where((final e) => !emptyCheck || e.isNotEmpty);
+    final bool noTrim = false,
+  }) => expand(
+    (final element) => element.splitAndTrim(
+      separator: separator,
+      emptyCheck: emptyCheck,
+      noTrim: noTrim,
+    ),
+  );
 }
 
 extension StringExtensions on String {
@@ -47,21 +53,29 @@ extension StringExtensions on String {
     final String separator = ',',
     final bool emptyCheck = true,
     final bool noTrim = false,
-  }) {
-    final filtered = split(separator)
-        .map((final el) => noTrim ? el : el.trim())
-        .where((final e) => !emptyCheck || e.isNotEmpty);
-    return LinkedHashSet<String>.from(filtered);
-  }
+  }) => LinkedHashSet<String>.from(
+    splitAndTrim(separator: separator, emptyCheck: emptyCheck, noTrim: noTrim),
+  );
+
+  /// Like [splitTrimAndFilterUnique] but preserves order and duplicates.
+  ///
+  /// Use this where each token is positional and a repeated token is significant.
+  Iterable<String> splitAndTrim({
+    final String separator = ',',
+    final bool emptyCheck = true,
+    final bool noTrim = false,
+  }) => split(separator)
+      .map((final el) => noTrim ? el : el.trim())
+      .where((final e) => !emptyCheck || e.isNotEmpty);
 
   /// Checks if the string is a valid email address.
-
   bool isValidEmail() {
     return RegExp(
       r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
     ).hasMatch(this);
   }
 
+  /// Checks if the string is a valid language code.
   bool isValidLanguageCode() {
     return RegExp(r'^[a-zA-Z]{2,8}(-[a-zA-Z]{2,8})?$').hasMatch(this);
   }

--- a/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
@@ -66,8 +66,18 @@ final class CookieHeader {
     return CookieHeader.cookies(cookies);
   }
 
+  /// Returns the first cookie named [name], or `null` if absent.
+  ///
+  /// A `Cookie` header may carry more than one cookie with the same name (RFC 6265 5.4).
+  /// Use [getCookies] when you must distinguish "exactly one" from a duplicate,
+  /// rather than blindly trusting the first.
   Cookie? getCookie(final String name) {
     return cookies.firstWhereOrNull((final cookie) => cookie.name == name);
+  }
+
+  /// Returns every cookie named [name], in header order (possibly empty).
+  Iterable<Cookie> getCookies(final String name) {
+    return cookies.where((final cookie) => cookie.name == name);
   }
 
   /// Converts the [CookieHeader] instance into a string representation

--- a/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
@@ -28,16 +28,40 @@ final class CookieHeader {
 
     final splitValues = value.splitTrimAndFilterUnique(separator: ';');
 
-    // RFC 6265 5.4 allows a Cookie header to carry several cookies with the
-    // same name (e.g. a host-only cookie plus a Domain-scoped one, or
-    // path-scoped duplicates); the server cannot tell them apart from the
-    // header alone. Keep such same-name cookies rather than rejecting the
-    // whole header, so one duplicate name does not make an otherwise valid
-    // cookie unreadable. splitTrimAndFilterUnique still collapses byte-identical
-    // segments, which is harmless since they are indistinguishable. [getCookie]
-    // returns the first match. Cookie names are case-sensitive per RFC 6265
-    // 4.2.2/5.4, so `Sid` and `sid` stay distinct.
-    final cookies = splitValues.map(Cookie.parse).toList();
+    // Parse each cookie independently and skip the malformed ones rather than
+    // rejecting the entire header. The Cookie header is a single line carrying
+    // every cookie the user agent decided to send; one invalid cookie (fx. a
+    // stray third-party cookie that does not meet RFC 6265's grammar) must not
+    // make the other, well-formed cookies - including a session or auth cookie
+    // - unreadable.
+    //
+    // RFC 6265 5.4 also allows a Cookie header to carry several cookies with
+    // the same name (a host-only cookie plus a Domain-scoped one, or
+    // path-scoped duplicates).
+    //
+    // The server cannot tell them apart from the header alone. Keep such
+    // same-name cookies rather than rejecting the whole header.
+    // splitTrimAndFilterUnique still collapses byte-identical segments, which
+    // is harmless since they are indistinguishable. [getCookie] returns the
+    // first match.
+    //
+    // Cookie names are case-sensitive per RFC 6265 4.2.2/5.4, so `Sid` and
+    // `sid` stay distinct.
+    final cookies = <Cookie>[];
+    for (final cookie in splitValues) {
+      try {
+        cookies.add(Cookie.parse(cookie));
+      } on FormatException {
+        // Skip this malformed cookie; keep the rest.
+      }
+    }
+
+    // The header is only treated as invalid when nothing in it is a usable
+    // cookie (an empty value is already rejected above). Consumers that want a
+    // tolerant read of a possibly-absent header can use `valueOrNullIfInvalid`.
+    if (cookies.isEmpty) {
+      throw const FormatException('No valid cookies in Cookie header');
+    }
 
     return CookieHeader.cookies(cookies);
   }

--- a/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
@@ -50,7 +50,12 @@ final class CookieHeader {
     final cookies = <Cookie>[];
     for (final cookie in splitValues) {
       try {
-        cookies.add(Cookie.parse(cookie));
+        final parsed = Cookie.parse(cookie);
+        // A nameless segment like `=value` (or a bare `=`) is not a cookie the
+        // client meaningfully set; skip it so such junk does not survive as an
+        // empty-named entry and slip past the "no valid cookies" guard below.
+        if (parsed.name.isEmpty) continue;
+        cookies.add(parsed);
       } on FormatException {
         // Skip this malformed cookie; keep the rest.
       }

--- a/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/cookie_header.dart
@@ -26,7 +26,7 @@ final class CookieHeader {
       throw const FormatException('Value cannot be empty');
     }
 
-    final splitValues = value.splitTrimAndFilterUnique(separator: ';');
+    final splitValues = value.splitAndTrim(separator: ';');
 
     // Parse each cookie independently and skip the malformed ones rather than
     // rejecting the entire header. The Cookie header is a single line carrying
@@ -39,10 +39,9 @@ final class CookieHeader {
     // the same name (a host-only cookie plus a Domain-scoped one, or
     // path-scoped duplicates).
     //
-    // The server cannot tell them apart from the header alone. Keep such
-    // same-name cookies rather than rejecting the whole header.
-    // splitTrimAndFilterUnique still collapses byte-identical segments, which
-    // is harmless since they are indistinguishable. [getCookie] returns the
+    // The server cannot tell them apart from the header alone, so keep every
+    // segment - including byte-identical duplicates - rather than collapsing
+    // them, so [getCookies] reports the true count. [getCookie] returns the
     // first match.
     //
     // Cookie names are case-sensitive per RFC 6265 4.2.2/5.4, so `Sid` and

--- a/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -126,15 +126,8 @@ final class SetCookie {
     }
 
     // RFC 6265 5.2: the first ';'-delimited token is the cookie-pair; every
-    // subsequent token is a cookie attribute (cookie-av). Splitting on the
-    // first '=' keeps a '=' that appears inside the value or an attribute.
-    final pair = splitValue.first;
-    final pairEq = pair.indexOf('=');
-    if (pairEq < 0) {
-      throw const FormatException('Invalid cookie format');
-    }
-    final cookieName = pair.substring(0, pairEq).trim();
-    final cookieValue = pair.substring(pairEq + 1).trim();
+    // subsequent token is a cookie attribute (cookie-av).
+    final pair = Cookie.parse(splitValue.first);
 
     bool secure = false;
     bool httpOnly = false;
@@ -192,8 +185,8 @@ final class SetCookie {
     }
 
     return SetCookie(
-      name: cookieName,
-      value: cookieValue,
+      name: pair.name,
+      value: pair.value,
       secure: secure,
       httpOnly: httpOnly,
       sameSite: sameSite,

--- a/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -107,7 +107,7 @@ final class SetCookie {
   /// Parses a single `Set-Cookie` line (without the header name) into a
   /// [SetCookie].
   factory SetCookie.parse(final String value) {
-    final splitValue = value.splitTrimAndFilterUnique(separator: ';');
+    final splitValue = value.splitAndTrim(separator: ';');
     if (splitValue.isEmpty) {
       throw const FormatException('Value cannot be empty');
     }

--- a/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -104,6 +104,17 @@ final class SetCookie {
     return domain;
   }
 
+  // RFC 6265 5.2.2: Max-Age is a decimal integer, optionally negative (a
+  // non-positive value expires the cookie). The generic numeric parser would
+  // also accept hex (`0xFF`) and other forms, silently reinterpreting the
+  // lifetime, so validate the decimal grammar before parsing.
+  static int _parseMaxAge(final String value) {
+    if (!RegExp(r'^-?\d+$').hasMatch(value)) {
+      throw const FormatException('Invalid Max-Age attribute');
+    }
+    return int.parse(value);
+  }
+
   /// Parses a single `Set-Cookie` line (without the header name) into a
   /// [SetCookie].
   factory SetCookie.parse(final String value) {
@@ -162,7 +173,7 @@ final class SetCookie {
           if (maxAge != null) {
             throw const FormatException('Supplied multiple Max-Age attributes');
           }
-          maxAge = parseInt(attrValue);
+          maxAge = _parseMaxAge(attrValue);
         case 'expires':
           if (expires != null) {
             throw const FormatException('Supplied multiple Expires attributes');

--- a/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -1,19 +1,19 @@
+import 'package:collection/collection.dart';
 import 'package:http_parser/http_parser.dart';
 import '../../../../relic_core.dart';
 
 import '../../extension/string_list_extensions.dart';
 import 'util/cookie_util.dart';
 
-/// A class representing the HTTP Set-Cookie header.
+/// A single HTTP `Set-Cookie` cookie: a name/value pair plus its attributes.
 ///
-/// This class manages the parsing and representation of set cookie.
-final class SetCookieHeader {
-  static const codec = HeaderCodec.single(SetCookieHeader.parse, __encode);
-  static List<String> __encode(final SetCookieHeader value) => [
-    value._encode(),
-  ];
-
-  /// The keys used for the Set-Cookie header.
+/// One `Set-Cookie` response header line maps to one [SetCookie]. A response
+/// may set several cookies; the set of them is the [SetCookieHeader]
+/// collection. Mirrors the request side, where one [Cookie] is an element of
+/// the [CookieHeader] collection (but a request [Cookie] carries no
+/// attributes).
+final class SetCookie {
+  /// The keys used for the Set-Cookie attributes.
   static const String _expires = 'Expires=';
   static const String _maxAge = 'Max-Age=';
   static const String _domain = 'Domain=';
@@ -62,12 +62,12 @@ final class SetCookieHeader {
   /// See [SameSite] for more information.
   final SameSite? sameSite;
 
-  /// Constructs a [Cookie] instance with the specified name and value.
+  /// Constructs a [SetCookie] with the specified name, value and attributes.
   ///
   /// Per RFC 6265 5.2.3 the `Domain` attribute is host-only, so [domain] must
   /// not carry a port; a [Host] with a port throws [FormatException]. [path]
   /// is validated against the path-value grammar (no CTLs or `;`).
-  SetCookieHeader({
+  SetCookie({
     required final String name,
     required final String value,
     this.expires,
@@ -89,14 +89,18 @@ final class SetCookieHeader {
         'Cookie Domain must not include a port (RFC 6265 5.2.3)',
       );
     }
-    // A leading '.' on the Domain attribute is allowed for historical reasons (RFC 6265 5.2.3)
+    // A leading '.' on the Domain attribute is historical (RFC 6265 5.2.3);
+    // normalize it away so `.example.com` is stored and emitted as the
+    // host-only `example.com`.
     if (domain.host.startsWith('.')) {
       return Host(domain.host.substring(1));
     }
     return domain;
   }
 
-  factory SetCookieHeader.parse(final String value) {
+  /// Parses a single `Set-Cookie` line (without the header name) into a
+  /// [SetCookie].
+  factory SetCookie.parse(final String value) {
     final splitValue = value.splitTrimAndFilterUnique(separator: ';');
     if (splitValue.isEmpty) {
       throw const FormatException('Value cannot be empty');
@@ -168,7 +172,7 @@ final class SetCookieHeader {
       }
     }
 
-    return SetCookieHeader(
+    return SetCookie(
       name: cookieName,
       value: cookieValue,
       secure: secure,
@@ -181,9 +185,9 @@ final class SetCookieHeader {
     );
   }
 
-  /// Converts the [Cookie] instance into a string representation suitable for HTTP headers.
-
-  String _encode() {
+  /// The wire form of this cookie: a single `Set-Cookie` value (without the
+  /// header name).
+  String encode() {
     // Each attribute is emitted at most once by construction, so a plain list
     // is correct here; a Set would silently collapse a cookie-pair whose name
     // coincides with an attribute rendering (e.g. name 'Path', value '/x').
@@ -209,7 +213,7 @@ final class SetCookieHeader {
   @override
   bool operator ==(final Object other) =>
       identical(this, other) ||
-      other is SetCookieHeader &&
+      other is SetCookie &&
           name == other.name &&
           value == other.value &&
           expires == other.expires &&
@@ -235,7 +239,7 @@ final class SetCookieHeader {
 
   @override
   String toString() {
-    return 'SetCookieHeader(name: $name, '
+    return 'SetCookie(name: $name, '
         'value: $value, '
         'expires: $expires, '
         'maxAge: $maxAge, '
@@ -247,9 +251,67 @@ final class SetCookieHeader {
   }
 }
 
+/// The HTTP `Set-Cookie` response header: the ordered set of [SetCookie]s a
+/// response sets.
+///
+/// Unlike most headers, `Set-Cookie` is emitted as one line per cookie and is
+/// never comma-folded (RFC 6265 4.1), so this is a true collection rather than
+/// a comma-list. Set it to replace the response's cookies; use [add]/[addAll]
+/// to augment without dropping existing ones:
+///
+/// ```dart
+/// mh.setCookie = (mh.setCookie ?? const SetCookieHeader.empty()).add(cookie);
+/// ```
+final class SetCookieHeader {
+  static const codec = HeaderCodec(SetCookieHeader.parse, _encode);
+
+  /// The cookies this header sets, in order.
+  final List<SetCookie> cookies;
+
+  /// Wraps [cookies] (defensively copied and unmodifiable).
+  SetCookieHeader(final List<SetCookie> cookies)
+    : cookies = List.unmodifiable(cookies);
+
+  /// An empty collection -- a convenient starting point for [add]/[addAll].
+  const SetCookieHeader.empty() : cookies = const [];
+
+  /// Parses the response's `Set-Cookie` header lines into a collection, one
+  /// [SetCookie] per line.
+  ///
+  /// Decoding is strict: a malformed line throws [FormatException] with the
+  /// specific reason. Unlike the request [CookieHeader] -- which skips a stray
+  /// malformed cookie sent by an untrusted client -- `Set-Cookie` is produced
+  /// by the server itself, so there is no lenient-skip rationale.
+  factory SetCookieHeader.parse(final Iterable<String> values) =>
+      SetCookieHeader(values.map(SetCookie.parse).toList());
+
+  /// Returns a new collection with [cookie] appended.
+  SetCookieHeader add(final SetCookie cookie) =>
+      SetCookieHeader([...cookies, cookie]);
+
+  /// Returns a new collection with all of [cookies] appended.
+  SetCookieHeader addAll(final Iterable<SetCookie> cookies) =>
+      SetCookieHeader([...this.cookies, ...cookies]);
+
+  static List<String> _encode(final SetCookieHeader value) =>
+      value.cookies.map((final c) => c.encode()).toList();
+
+  @override
+  bool operator ==(final Object other) =>
+      identical(this, other) ||
+      other is SetCookieHeader &&
+          const ListEquality<SetCookie>().equals(cookies, other.cookies);
+
+  @override
+  int get hashCode => const ListEquality<SetCookie>().hash(cookies);
+
+  @override
+  String toString() => 'SetCookieHeader(cookies: $cookies)';
+}
+
 /// Cookie cross-site availability configuration.
 ///
-/// The value of [Cookie.sameSite], which defines whether an
+/// The value of [SetCookie.sameSite], which defines whether an
 /// HTTP cookie is available from other sites or not.
 ///
 /// Has three possible values: [lax], [strict] and [none].
@@ -263,7 +325,7 @@ final class SameSite {
 
   /// Cookie with this value will be sent in all requests.
   ///
-  /// [Cookie.secure] must also be set to true, otherwise the `none` value
+  /// [SetCookie.secure] must also be set to true, otherwise the `none` value
   /// will have no effect.
   static const none = SameSite._('None');
 

--- a/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -92,16 +92,18 @@ final class SetCookie {
     // A leading '.' on the Domain attribute is historical (RFC 6265 5.2.3);
     // normalize it away so `.example.com` is stored and emitted as the
     // host-only `example.com`.
-    if (domain.host.startsWith('.')) {
-      final stripped = domain.host.replaceFirst(RegExp(r'^\.+'), '');
-      if (stripped.isEmpty) {
+    var host = domain.host;
+    if (host.startsWith('.')) {
+      host = host.replaceFirst(RegExp(r'^\.+'), '');
+      if (host.isEmpty) {
         throw const FormatException(
           'Cookie Domain must not be only dots (RFC 6265 5.2.3)',
         );
       }
-      return Host(stripped);
     }
-    return domain;
+    // Normalize to lower-case as per RFC 6265 5.2.3.
+    host = host.toLowerCase();
+    return host == domain.host ? domain : Host(host);
   }
 
   // RFC 6265 5.2.2: Max-Age is a decimal integer, optionally negative (a

--- a/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -93,7 +93,13 @@ final class SetCookie {
     // normalize it away so `.example.com` is stored and emitted as the
     // host-only `example.com`.
     if (domain.host.startsWith('.')) {
-      return Host(domain.host.substring(1));
+      final stripped = domain.host.replaceFirst(RegExp(r'^\.+'), '');
+      if (stripped.isEmpty) {
+        throw const FormatException(
+          'Cookie Domain must not be only dots (RFC 6265 5.2.3)',
+        );
+      }
+      return Host(stripped);
     }
     return domain;
   }

--- a/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
+++ b/packages/relic_core/lib/src/headers/typed/headers/set_cookie_header.dart
@@ -83,10 +83,15 @@ final class SetCookieHeader {
        path = path == null ? null : validateCookiePath(path);
 
   static Host? _validateCookieDomain(final Host? domain) {
-    if (domain != null && domain.port != null) {
+    if (domain == null) return null;
+    if (domain.port != null) {
       throw const FormatException(
         'Cookie Domain must not include a port (RFC 6265 5.2.3)',
       );
+    }
+    // A leading '.' on the Domain attribute is allowed for historical reasons (RFC 6265 5.2.3)
+    if (domain.host.startsWith('.')) {
+      return Host(domain.host.substring(1));
     }
     return domain;
   }

--- a/packages/relic_core/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/cookie_header_test.dart
@@ -20,6 +20,16 @@ void main() {
 
         expect(h.getCookie('sid')?.value, equals('a'));
       });
+
+      test('when the duplicates are byte-identical, '
+          'then they are not collapsed and getCookies returns each.', () {
+        final h = CookieHeader.parse('sid=a; sid=a');
+
+        expect(
+          h.getCookies('sid').map((final c) => c.value),
+          equals(['a', 'a']),
+        );
+      });
     });
 
     group('Given no cookie with the requested name,', () {

--- a/packages/relic_core/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/cookie_header_test.dart
@@ -32,4 +32,27 @@ void main() {
       });
     });
   });
+
+  group('CookieHeader nameless segments', () {
+    group('Given a nameless `=value` segment alongside a valid cookie,', () {
+      test(
+        'when parsed, '
+        'then the nameless segment is dropped and the valid cookie kept.',
+        () {
+          final h = CookieHeader.parse('auth=tok; =garbage');
+
+          expect(h.cookies.map((final c) => c.name), equals(['auth']));
+          expect(h.getCookie(''), isNull);
+        },
+      );
+    });
+
+    group('Given a header that is only nameless segments,', () {
+      test('when parsed, '
+          'then it throws (no usable cookie remains).', () {
+        expect(() => CookieHeader.parse('='), throwsFormatException);
+        expect(() => CookieHeader.parse('=a; =b'), throwsFormatException);
+      });
+    });
+  });
 }

--- a/packages/relic_core/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/cookie_header_test.dart
@@ -1,0 +1,35 @@
+import 'package:relic_core/relic_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CookieHeader cookie lookup', () {
+    group('Given duplicate cookies with the same name,', () {
+      test('when getCookies is called, '
+          'then all matches are returned in order.', () {
+        final h = CookieHeader.parse('sid=a; other=x; sid=b');
+
+        expect(
+          h.getCookies('sid').map((final c) => c.value).toList(),
+          equals(['a', 'b']),
+        );
+      });
+
+      test('when getCookie is called, '
+          'then only the first match is returned.', () {
+        final h = CookieHeader.parse('sid=a; other=x; sid=b');
+
+        expect(h.getCookie('sid')?.value, equals('a'));
+      });
+    });
+
+    group('Given no cookie with the requested name,', () {
+      test('when getCookies is called, '
+          'then the result is empty.', () {
+        final h = CookieHeader.parse('sid=a');
+
+        expect(h.getCookies('missing'), isEmpty);
+        expect(h.getCookie('missing'), isNull);
+      });
+    });
+  });
+}

--- a/packages/relic_core/test/headers/typed/cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/cookie_header_test.dart
@@ -43,6 +43,39 @@ void main() {
     });
   });
 
+  group('CookieHeader skip-malformed ordering', () {
+    group('Given a malformed cookie before a valid one,', () {
+      test('when parsed, '
+          'then the malformed cookie is skipped and the valid one kept.', () {
+        final h = CookieHeader.parse('invalid cookie; sessionId=abc');
+
+        expect(h.cookies.map((final c) => c.name), equals(['sessionId']));
+      });
+    });
+
+    group('Given a malformed cookie after a valid one,', () {
+      test('when parsed, '
+          'then the malformed cookie is skipped and the valid one kept.', () {
+        final h = CookieHeader.parse('sessionId=abc; invalid cookie');
+
+        expect(h.cookies.map((final c) => c.name), equals(['sessionId']));
+      });
+    });
+  });
+
+  group('CookieHeader name case-sensitivity', () {
+    group('Given two cookies whose names differ only in case,', () {
+      test('when parsed, '
+          'then they are kept distinct (RFC 6265 4.2.2/5.4).', () {
+        final h = CookieHeader.parse('Sid=a; sid=b');
+
+        expect(h.cookies.map((final c) => c.name), equals(['Sid', 'sid']));
+        expect(h.getCookie('Sid')?.value, equals('a'));
+        expect(h.getCookie('sid')?.value, equals('b'));
+      });
+    });
+  });
+
   group('CookieHeader nameless segments', () {
     group('Given a nameless `=value` segment alongside a valid cookie,', () {
       test(

--- a/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
@@ -238,6 +238,73 @@ void main() {
     });
   });
 
+  group('SetCookie Secure flag', () {
+    group('Given a cookie with secure false (the default),', () {
+      test('when encoded, '
+          'then the Secure attribute is omitted.', () {
+        final cookie = SetCookie(name: 'sid', value: 'abc');
+
+        expect(cookie.secure, isFalse);
+        expect(cookie.encode(), equals('sid=abc'));
+      });
+    });
+
+    group('Given a cookie with secure true,', () {
+      test('when encoded, '
+          'then the Secure attribute is present.', () {
+        final cookie = SetCookie(name: 'sid', value: 'abc', secure: true);
+
+        expect(cookie.encode(), equals('sid=abc; Secure'));
+      });
+    });
+  });
+
+  group('SetCookie equality', () {
+    group('Given two SetCookies with identical fields,', () {
+      test('when compared, '
+          'then they are equal and share a hashCode.', () {
+        final x = SetCookie(name: 'a', value: '1', secure: true);
+        final y = SetCookie(name: 'a', value: '1', secure: true);
+
+        expect(x, equals(y));
+        expect(x.hashCode, equals(y.hashCode));
+      });
+    });
+
+    group('Given two SetCookies that differ in one field,', () {
+      test('when compared, '
+          'then they are not equal.', () {
+        final x = SetCookie(name: 'a', value: '1');
+        final y = SetCookie(name: 'a', value: '2');
+
+        expect(x, isNot(equals(y)));
+      });
+    });
+  });
+
+  group('SetCookieHeader equality', () {
+    group('Given two collections with equal cookies,', () {
+      test('when compared, '
+          'then they are equal and share a hashCode.', () {
+        final x = SetCookieHeader([SetCookie(name: 'a', value: '1')]);
+        final y = SetCookieHeader([SetCookie(name: 'a', value: '1')]);
+
+        expect(x, equals(y));
+        expect(x.hashCode, equals(y.hashCode));
+      });
+    });
+
+    group('Given two collections with different cookies,', () {
+      test('when compared, '
+          'then they are not equal.', () {
+        final x = SetCookieHeader([SetCookie(name: 'a', value: '1')]);
+        final y = SetCookieHeader([SetCookie(name: 'b', value: '2')]);
+
+        expect(x, isNot(equals(y)));
+      });
+    });
+  });
+
   group('SetCookieHeader collection', () {
     final a = SetCookie(name: 'a', value: '1');
     final b = SetCookie(name: 'b', value: '2', secure: true);
@@ -271,6 +338,25 @@ void main() {
       test('when addAll is called, '
           'then all cookies are appended in order.', () {
         expect(SetCookieHeader([a]).addAll([b]).cookies, equals([a, b]));
+      });
+    });
+
+    group('Given the const empty collection,', () {
+      test('when add/addAll is called, '
+          'then a new collection is returned and empty() stays empty.', () {
+        const empty = SetCookieHeader.empty();
+
+        expect(empty.add(a).cookies, equals([a]));
+        expect(empty.addAll([a, b]).cookies, equals([a, b]));
+        expect(empty.cookies, isEmpty);
+      });
+
+      test('when its cookies list is mutated, '
+          'then it throws (the list is unmodifiable).', () {
+        expect(
+          () => SetCookieHeader([a]).cookies.add(b),
+          throwsUnsupportedError,
+        );
       });
     });
 

--- a/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
@@ -74,6 +74,30 @@ void main() {
         expect(parsed.domain?.host, equals('example.com'));
       });
     });
+
+    group('Given a Domain with several leading dots,', () {
+      test('when constructed, '
+          'then the whole leading run is stripped (not just one).', () {
+        final cookie = SetCookie(
+          name: 'sid',
+          value: 'abc',
+          domain: Host('..example.com'),
+        );
+
+        expect(cookie.domain?.host, equals('example.com'));
+        expect(cookie.encode(), contains('Domain=example.com'));
+      });
+    });
+
+    group('Given a Domain that is only dots,', () {
+      test('when constructed, '
+          'then it throws rather than emitting an empty Host.', () {
+        expect(
+          () => SetCookie(name: 'sid', value: 'abc', domain: Host('.')),
+          throwsFormatException,
+        );
+      });
+    });
   });
 
   group('SetCookie parser hardening', () {

--- a/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
@@ -191,6 +191,32 @@ void main() {
     });
   });
 
+  group('SetCookie Max-Age attribute', () {
+    group('Given a decimal Max-Age,', () {
+      test('when parsed, '
+          'then it is accepted.', () {
+        expect(SetCookie.parse('a=b; Max-Age=3600').maxAge, equals(3600));
+      });
+    });
+
+    group('Given a negative Max-Age,', () {
+      test('when parsed, '
+          'then it is accepted (a non-positive value expires the cookie).', () {
+        expect(SetCookie.parse('a=b; Max-Age=-1').maxAge, equals(-1));
+      });
+    });
+
+    group('Given a hexadecimal Max-Age,', () {
+      test('when parsed, '
+          'then it throws (RFC 6265 5.2.2 allows decimal digits only).', () {
+        expect(
+          () => SetCookie.parse('a=b; Max-Age=0xFF'),
+          throwsFormatException,
+        );
+      });
+    });
+  });
+
   group('SetCookieHeader collection', () {
     final a = SetCookie(name: 'a', value: '1');
     final b = SetCookie(name: 'b', value: '2', secure: true);

--- a/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
@@ -122,6 +122,24 @@ void main() {
       });
     });
 
+    group('Given a duplicated attribute,', () {
+      test('when the duplicates are byte-identical, '
+          'then it still throws (the split must not dedup them away).', () {
+        expect(
+          () => SetCookie.parse('a=x; Path=/p; Path=/p'),
+          throwsFormatException,
+        );
+      });
+
+      test('when the duplicates differ, '
+          'then it throws (consistent with the identical case).', () {
+        expect(
+          () => SetCookie.parse('a=x; Path=/p; Path=/q'),
+          throwsFormatException,
+        );
+      });
+    });
+
     group('Given a Path attribute value that contains an "=",', () {
       test('when parsed, '
           'then the full path after the first "=" is preserved.', () {

--- a/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
@@ -2,58 +2,49 @@ import 'package:relic_core/relic_core.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('SetCookieHeader Domain attribute (regression for #355)', () {
-    group('Given a SetCookieHeader with a Host domain,', () {
+  group('SetCookie Domain attribute (regression for #355)', () {
+    group('Given a SetCookie with a Host domain,', () {
       test('when encoded via codec, '
           'then Domain= carries only the hostname (no scheme or slashes).', () {
-        final cookie = SetCookieHeader(
+        final cookie = SetCookie(
           name: 'sid',
           value: 'abc',
           domain: Host('abc.co'),
         );
 
-        expect(
-          SetCookieHeader.codec.encode(cookie).single,
-          equals('sid=abc; Domain=abc.co'),
-        );
+        expect(cookie.encode(), equals('sid=abc; Domain=abc.co'));
       });
 
       test('when constructed with an IPv6 host, '
           'then Domain= encodes it bracketed.', () {
-        final cookie = SetCookieHeader(
+        final cookie = SetCookie(
           name: 'sid',
           value: 'abc',
           domain: Host('::1'),
         );
 
-        expect(
-          SetCookieHeader.codec.encode(cookie).single,
-          contains('Domain=[::1]'),
-        );
+        expect(cookie.encode(), contains('Domain=[::1]'));
       });
     });
 
     group('Given a Set-Cookie wire value with a Domain attribute,', () {
       test('when parsed and re-encoded, '
           'then the Domain hostname round-trips.', () {
-        final parsed = SetCookieHeader.parse(
+        final parsed = SetCookie.parse(
           'sid=abc; Domain=example.com; Path=/api',
         );
 
         expect(parsed.domain?.host, equals('example.com'));
         expect(parsed.path, equals('/api'));
-        expect(
-          SetCookieHeader.codec.encode(parsed).single,
-          contains('Domain=example.com'),
-        );
+        expect(parsed.encode(), contains('Domain=example.com'));
       });
     });
 
     group('Given a Host domain that carries a port,', () {
-      test('when used to construct a SetCookieHeader, '
+      test('when used to construct a SetCookie, '
           'then it throws (RFC 6265 5.2.3 forbids a port in Domain).', () {
         expect(
-          () => SetCookieHeader(
+          () => SetCookie(
             name: 'sid',
             value: 'abc',
             domain: Host('example.com', 8080),
@@ -66,33 +57,30 @@ void main() {
     group('Given a Domain with a leading dot,', () {
       test('when constructed, '
           'then the dot is stripped (RFC 6265 5.2.3 normalization).', () {
-        final header = SetCookieHeader(
+        final header = SetCookie(
           name: 'sid',
           value: 'abc',
           domain: Host('.example.com'),
         );
 
         expect(header.domain?.host, equals('example.com'));
-        expect(
-          SetCookieHeader.codec.encode(header).single,
-          contains('Domain=example.com'),
-        );
+        expect(header.encode(), contains('Domain=example.com'));
       });
 
       test('when parsed from the wire, '
           'then the dot is stripped.', () {
-        final parsed = SetCookieHeader.parse('sid=abc; Domain=.example.com');
+        final parsed = SetCookie.parse('sid=abc; Domain=.example.com');
 
         expect(parsed.domain?.host, equals('example.com'));
       });
     });
   });
 
-  group('SetCookieHeader parser hardening', () {
+  group('SetCookie parser hardening', () {
     group('Given a cookie name that contains an attribute keyword,', () {
       test('when parsed, '
           'then the first pair is the cookie, not the attribute.', () {
-        final parsed = SetCookieHeader.parse('sessionhttponly=xyz');
+        final parsed = SetCookie.parse('sessionhttponly=xyz');
 
         expect(parsed.name, equals('sessionhttponly'));
         expect(parsed.value, equals('xyz'));
@@ -103,7 +91,7 @@ void main() {
     group('Given a cookie value that contains an "=",', () {
       test('when parsed, '
           'then only the first "=" splits name from value.', () {
-        final parsed = SetCookieHeader.parse('token=a=b=c');
+        final parsed = SetCookie.parse('token=a=b=c');
 
         expect(parsed.name, equals('token'));
         expect(parsed.value, equals('a=b=c'));
@@ -113,7 +101,7 @@ void main() {
     group('Given a Path attribute value that contains an "=",', () {
       test('when parsed, '
           'then the full path after the first "=" is preserved.', () {
-        final parsed = SetCookieHeader.parse('sid=x; Path=/foo=bar');
+        final parsed = SetCookie.parse('sid=x; Path=/foo=bar');
 
         expect(parsed.path, equals('/foo=bar'));
       });
@@ -122,9 +110,9 @@ void main() {
     group('Given a cookie name equal to an attribute label,', () {
       test('when encoded, '
           'then the cookie-pair is not collapsed with the attribute.', () {
-        final cookie = SetCookieHeader(name: 'Path', value: '/foo', path: '/x');
+        final cookie = SetCookie(name: 'Path', value: '/foo', path: '/x');
 
-        final encoded = SetCookieHeader.codec.encode(cookie).single;
+        final encoded = cookie.encode();
         expect(encoded, contains('Path=/foo'));
         expect(encoded, contains('Path=/x'));
         expect(encoded, equals('Path=/foo; Path=/x'));
@@ -132,10 +120,10 @@ void main() {
     });
 
     group('Given a path containing a control character,', () {
-      test('when used to construct a SetCookieHeader, '
+      test('when used to construct a SetCookie, '
           'then it throws to prevent header injection.', () {
         expect(
-          () => SetCookieHeader(
+          () => SetCookie(
             name: 'sid',
             value: 'x',
             path: '/foo\r\nSet-Cookie: evil=1',
@@ -148,15 +136,63 @@ void main() {
     group('Given an empty cookie name (the "=value" quirk),', () {
       test('when encoded, '
           'then the cookie-pair is still emitted and round-trips.', () {
-        final cookie = SetCookieHeader(name: '', value: 'abc123', secure: true);
+        final cookie = SetCookie(name: '', value: 'abc123', secure: true);
 
-        final encoded = SetCookieHeader.codec.encode(cookie).single;
+        final encoded = cookie.encode();
         expect(encoded, equals('=abc123; Secure'));
 
-        final reparsed = SetCookieHeader.parse(encoded);
+        final reparsed = SetCookie.parse(encoded);
         expect(reparsed.name, isEmpty);
         expect(reparsed.value, equals('abc123'));
         expect(reparsed.secure, isTrue);
+      });
+    });
+  });
+
+  group('SetCookieHeader collection', () {
+    final a = SetCookie(name: 'a', value: '1');
+    final b = SetCookie(name: 'b', value: '2', secure: true);
+
+    group('Given several Set-Cookie lines,', () {
+      test('when decoded, '
+          'then each line is one cookie, in order.', () {
+        final header = SetCookieHeader.codec.decode(['a=1', 'b=2; Secure']);
+
+        expect(header.cookies.map((final c) => c.name), equals(['a', 'b']));
+        expect(header.cookies[1].secure, isTrue);
+      });
+
+      test('when encoded, '
+          'then each cookie is its own Set-Cookie line.', () {
+        expect(
+          SetCookieHeader.codec.encode(SetCookieHeader([a, b])),
+          equals(['a=1', 'b=2; Secure']),
+        );
+      });
+    });
+
+    group('Given an existing collection,', () {
+      test('when add is called, '
+          'then a new collection with the cookie appended is returned.', () {
+        final header = const SetCookieHeader.empty().add(a).add(b);
+
+        expect(header.cookies, equals([a, b]));
+      });
+
+      test('when addAll is called, '
+          'then all cookies are appended in order.', () {
+        expect(SetCookieHeader([a]).addAll([b]).cookies, equals([a, b]));
+      });
+    });
+
+    group('Given a malformed Set-Cookie line,', () {
+      test('when decoded, '
+          'then it throws (strict decode)', () {
+        // Set-Cookie is server-produced, so there is no need to be lenient
+        expect(
+          () => SetCookieHeader.codec.decode(['a=1', 'no-equals', 'b=2']),
+          throwsFormatException,
+        );
       });
     });
   });

--- a/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
@@ -98,6 +98,27 @@ void main() {
         );
       });
     });
+
+    group('Given an uppercase Domain,', () {
+      test('when constructed, '
+          'then it is lower-cased (RFC 6265 5.2.3).', () {
+        final cookie = SetCookie(
+          name: 'sid',
+          value: 'abc',
+          domain: Host('EXAMPLE.COM'),
+        );
+
+        expect(cookie.domain?.host, equals('example.com'));
+        expect(cookie.encode(), contains('Domain=example.com'));
+      });
+
+      test('when parsed from the wire (with a leading dot), '
+          'then it is lower-cased.', () {
+        final parsed = SetCookie.parse('sid=abc; Domain=.EXAMPLE.COM');
+
+        expect(parsed.domain?.host, equals('example.com'));
+      });
+    });
   });
 
   group('SetCookie parser hardening', () {

--- a/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
+++ b/packages/relic_core/test/headers/typed/set_cookie_header_test.dart
@@ -62,6 +62,30 @@ void main() {
         );
       });
     });
+
+    group('Given a Domain with a leading dot,', () {
+      test('when constructed, '
+          'then the dot is stripped (RFC 6265 5.2.3 normalization).', () {
+        final header = SetCookieHeader(
+          name: 'sid',
+          value: 'abc',
+          domain: Host('.example.com'),
+        );
+
+        expect(header.domain?.host, equals('example.com'));
+        expect(
+          SetCookieHeader.codec.encode(header).single,
+          contains('Domain=example.com'),
+        );
+      });
+
+      test('when parsed from the wire, '
+          'then the dot is stripped.', () {
+        final parsed = SetCookieHeader.parse('sid=abc; Domain=.example.com');
+
+        expect(parsed.domain?.host, equals('example.com'));
+      });
+    });
   });
 
   group('SetCookieHeader parser hardening', () {


### PR DESCRIPTION
## Description
Hardens cookie header handling and reshapes the Set-Cookie types so the single-cookie value and the header collection are distinct, matching the request side.

- Rename the single-cookie class `SetCookieHeader` -> `SetCookie` (name/value + attributes)
- `SetCookieHeader` is now a `List<SetCookie>` collection, one element per `Set-Cookie` response line 
  (never comma-folded, RFC 6265 4.1).
- `SetCookieHeader` gains `.empty()`, `add`, `addAll`, value equality, and a multi-value codec
- `SetCookie.encode()` is now public.
- `CookieHeader.parse` is lenient: skip malformed cookies and keep the well-formed ones.
  One bad third-party cookie no longer hides a valid session/auth cookie. Throw only when no usable cookie remains. 
- `SetCookieHeader.parse` stays strict (server-produced, no skip rationale).
- Add `CookieHeader.getCookies(name)` returning every match in header order.
- `getCookie` returns the first of possible duplicates (RFC 6265 5.4).
- `SetCookie` strips a leading dot from the `Domain` (RFC 6265 5.2.3).

## Related Issues
- Related: #113 

## Pre-Launch Checklist
- [x] This update focuses on a single feature or bug fix.
- [x] I have read and followed the Dart Style Guide and formatted with dart format.
- [x] I have referenced at least one issue this PR fixes or is related to.
- [x] I have updated/added relevant documentation (doc comments with `///`).
- [x] I have added new tests to verify the changes.
- [x] All existing and new tests pass successfully.
- [x] I have documented any breaking changes below.

## Breaking Changes
- [x] Includes breaking changes.
- [ ] No breaking changes.
