### PR TITLE
refactor: No normalized path interning

### DIFF
--- a/packages/relic/test/router/relic_app_test.dart
+++ b/packages/relic/test/router/relic_app_test.dart
@@ -39,6 +39,34 @@ void main() {
       );
     });
 
+    test('Given a RelicApp with a route, '
+        'when calling lookupUri, '
+        'then it delegates to the underlying router', () {
+      Response handler(final Request req) => Response.ok();
+      final app = RelicApp()..get('/a/b', handler);
+
+      // The query and fragment are not part of the route path.
+      final hit = app.lookupUri(
+        Method.get,
+        Uri.parse('http://example.com/a/b?q=1#frag'),
+      );
+      expect(hit, isA<RouterMatch<Handler>>());
+      expect((hit as RouterMatch<Handler>).value, same(handler));
+
+      expect(
+        app.lookupUri(Method.post, Uri.parse('http://example.com/a/b')),
+        isA<MethodMiss<Handler>>(),
+      );
+      expect(
+        app.lookupUri(
+          Method.get,
+          Uri.parse('http://example.com/nope'),
+          backtrack: false,
+        ),
+        isA<PathMiss<Handler>>(),
+      );
+    });
+
     test('Given a RelicApp, '
         'when calling run with adapter factory, '
         'then it creates a RelicServer and mounts the handler', () async {

--- a/packages/relic_core/lib/src/middleware/routing_middleware.dart
+++ b/packages/relic_core/lib/src/middleware/routing_middleware.dart
@@ -110,11 +110,15 @@ class _RoutingMiddlewareBuilder<T extends Object> {
 
   Handler call(final Handler next) {
     return (final req) async {
-      final path = NormalizedPath.fromUri(req.url);
-      final routingKey = useHostWhenRouting
-          ? NormalizedPath.fromSegments([req.url.host, ...path.segments])
-          : path;
-      final result = _router.lookupPath(req.method, routingKey);
+      final result = useHostWhenRouting
+          ? _router.lookupPath(
+              req.method,
+              NormalizedPath.fromSegments([
+                req.url.host,
+                ...NormalizedPath.fromUri(req.url).segments,
+              ]),
+            )
+          : _router.lookupUri(req.method, req.url);
       switch (result) {
         case MethodMiss():
           return Response(

--- a/packages/relic_core/lib/src/router/no_cache.dart
+++ b/packages/relic_core/lib/src/router/no_cache.dart
@@ -1,14 +1,7 @@
 import 'cache.dart';
 
-/// A no-op [Cache] implementation that never stores or retrieves values.
-///
-/// Useful for high-cardinality workloads where caching causes more overhead
-/// than it saves (e.g., many unique dynamic paths like `/users/:id`).
-///
-/// Example:
-/// ```dart
-/// NormalizedPath.interned = NoCache();
-/// ```
+/// A no-op [Cache] that never stores or retrieves values, for opting out of
+/// caching in high-cardinality workloads where it costs more than it saves.
 final class NoCache<K, V> implements Cache<K, V> {
   /// Creates a no-op cache.
   const NoCache();

--- a/packages/relic_core/lib/src/router/normalized_path.dart
+++ b/packages/relic_core/lib/src/router/normalized_path.dart
@@ -1,8 +1,5 @@
 import 'package:meta/meta.dart';
 
-import 'cache.dart';
-import 'lru_cache.dart';
-
 /// Represents a URL path that has been normalized.
 ///
 /// Normalization includes:
@@ -10,28 +7,11 @@ import 'lru_cache.dart';
 /// - Removing empty segments caused by multiple consecutive slashes.
 /// - Ensuring the path starts with a `/`.
 ///
-/// Instances created from a path string are interned using an LRU cache for
-/// efficiency, so identical paths will often share the same object instance.
-/// Segment-built instances ([fromSegments], [fromUri]) are never interned: a
-/// string cache key cannot tell a separator inside a segment from a real one.
-/// Equality compares segments, so this affects allocation only.
+/// Equality and [hashCode] are derived from [segments], so paths with the same
+/// segments are equal regardless of how they were built. Construction does no
+/// caching.
 @immutable
 class NormalizedPath {
-  /// Cache of interned instances.
-  ///
-  /// Defaults to an [LruCache] with 10,000 entries. Can be replaced with any
-  /// [Cache] implementation to tune caching behavior:
-  ///
-  /// ```dart
-  /// // Disable caching for high-cardinality workloads
-  /// NormalizedPath.interned = NoCache();
-  ///
-  /// // Use a larger cache
-  /// NormalizedPath.interned = LruCache(50000);
-  /// ```
-  static Cache<String, NormalizedPath> interned =
-      LruCache<String, NormalizedPath>(10000);
-
   /// The individual segments of the normalized path.
   /// For example, the path `/a/b/c` would have segments `['a', 'b', 'c']`.
   final List<String> segments;
@@ -44,20 +24,12 @@ class NormalizedPath {
 
   /// Creates a [NormalizedPath] from a given [path] string.
   ///
-  /// The provided [path] will be normalized by resolving `.` and `..` segments
-  /// and removing empty segments. The resulting [NormalizedPath] instance may be
-  /// retrieved from a cache if an identical normalized path has been created
-  /// recently.
-  factory NormalizedPath(final String path) {
-    var result = interned[path];
-    if (result == null) {
-      result = NormalizedPath._(_normalizeSegments(path.split('/')));
-      // intern for both normalized path and path
-      result = interned[result.path] ??= result;
-      interned[path] = result; // cache for original path as well
-    }
-    return result;
-  }
+  /// The provided [path] is split on `/` and normalized by resolving `.` and
+  /// `..` segments and removing empty ones. The path is not percent-decoded,
+  /// so an encoded separator such as `%2F` stays literal within its segment;
+  /// use [NormalizedPath.fromUri] to derive a path from a request.
+  factory NormalizedPath(final String path) =>
+      NormalizedPath._(_normalizeSegments(path.split('/')));
 
   /// Creates a [NormalizedPath] from segments that have already been split.
   ///

--- a/packages/relic_core/lib/src/router/normalized_path.dart
+++ b/packages/relic_core/lib/src/router/normalized_path.dart
@@ -43,14 +43,18 @@ class NormalizedPath {
 
   /// Creates a [NormalizedPath] from the path of [url].
   ///
-  /// This is the correct way to derive a path from a request. It reads
-  /// [Uri.pathSegments], which splits on the separator and only then decodes
-  /// each segment, so an encoded separator such as `%2F` stays inside its
-  /// segment. Building from [Uri.path] instead would decode first and then
-  /// split, introducing separators that no proxy in front of the server ever
-  /// saw.
-  factory NormalizedPath.fromUri(final Uri url) =>
-      NormalizedPath.fromSegments(url.pathSegments);
+  /// [Uri.pathSegments] splits on the separator before decoding, so an encoded
+  /// separator (`%2F`) stays within its segment.
+  factory NormalizedPath.fromUri(final Uri url) {
+    final segments = url.pathSegments;
+    // Reuse the unmodifiable pathSegments if clean
+    for (final segment in segments) {
+      if (segment.isEmpty || segment == '.' || segment == '..') {
+        return NormalizedPath._(_normalizeSegments(segments));
+      }
+    }
+    return NormalizedPath._(segments);
+  }
 
   /// Normalizes [segments] by resolving `.` and `..` and dropping empty ones.
   static List<String> _normalizeSegments(final Iterable<String> segments) {

--- a/packages/relic_core/lib/src/router/path_trie.dart
+++ b/packages/relic_core/lib/src/router/path_trie.dart
@@ -60,7 +60,10 @@ sealed class _DynamicSegment<T> {
 final class _Parameter<T> extends _DynamicSegment<T> {
   final String name;
 
-  _Parameter(this.name);
+  /// The parameter [name] as a [Symbol], precomputed for use during lookup.
+  final Symbol symbol;
+
+  _Parameter(this.name) : symbol = Symbol(name);
 }
 
 final class _Wildcard<T> extends _DynamicSegment<T> {}
@@ -392,7 +395,13 @@ final class PathTrie<T extends Object> {
     final bool backtrack = true,
   }) {
     return backtrack
-        ? _lookupRecursive(_root, normalizedPath, 0, _root.map, const {})
+        ? _lookupRecursive(
+            _root,
+            normalizedPath,
+            0,
+            _root.map,
+            <Symbol, String>{},
+          )
         : _lookupIterative(normalizedPath);
   }
 
@@ -432,17 +441,14 @@ final class PathTrie<T extends Object> {
 
     final segment = segments[index];
 
+    TrieMatch<T>? next(_TrieNode<T> node, final T Function(T)? map) =>
+        _lookupRecursive(node, normalizedPath, index + 1, map, parameters);
+
     // Try literal match first
     final child = node.children[segment];
     if (child != null) {
       final newMap = _composeMap(currentMap, child.map);
-      final result = _lookupRecursive(
-        child,
-        normalizedPath,
-        index + 1,
-        newMap,
-        parameters,
-      );
+      final result = next(child, newMap);
       if (result != null) return result;
       // Fall through to try dynamic segment
     }
@@ -452,9 +458,6 @@ final class PathTrie<T extends Object> {
     if (dynamicSegment != null) {
       final dynamicNode = dynamicSegment.node;
       final newMap = _composeMap(currentMap, dynamicNode.map);
-      final newParams = dynamicSegment is _Parameter<T>
-          ? {...parameters, Symbol(dynamicSegment.name): segment}
-          : parameters;
 
       if (dynamicSegment is _Tail<T>) {
         // Tail matches: check for value at this position
@@ -463,19 +466,18 @@ final class PathTrie<T extends Object> {
           value = newMap?.call(value) ?? value;
           return TrieMatch(
             value,
-            newParams,
+            parameters,
             normalizedPath.subPath(0, index),
             normalizedPath.subPath(index),
           );
         }
+      } else if (dynamicSegment is _Parameter<T>) {
+        parameters[dynamicSegment.symbol] = segment;
+        final result = next(dynamicNode, newMap);
+        if (result != null) return result;
+        parameters.remove(dynamicSegment.symbol); // backtrack
       } else {
-        return _lookupRecursive(
-          dynamicNode,
-          normalizedPath,
-          index + 1,
-          newMap,
-          newParams,
-        );
+        return next(dynamicNode, newMap);
       }
     }
 
@@ -524,7 +526,7 @@ final class PathTrie<T extends Object> {
         currentNode = dynamicSegment.node;
         updateMap();
         if (dynamicSegment case final _Parameter<T> parameter) {
-          parameters[Symbol(parameter.name)] = segment;
+          parameters[parameter.symbol] = segment;
         }
         if (dynamicSegment is _Tail<T>) break; // possible early match
       }

--- a/packages/relic_core/lib/src/router/path_trie.dart
+++ b/packages/relic_core/lib/src/router/path_trie.dart
@@ -472,10 +472,15 @@ final class PathTrie<T extends Object> {
           );
         }
       } else if (dynamicSegment is _Parameter<T>) {
+        final prev = parameters[dynamicSegment.symbol];
         parameters[dynamicSegment.symbol] = segment;
         final result = next(dynamicNode, newMap);
         if (result != null) return result;
-        parameters.remove(dynamicSegment.symbol); // backtrack
+        if (prev == null) {
+          parameters.remove(dynamicSegment.symbol);
+        } else {
+          parameters[dynamicSegment.symbol] = prev;
+        }
       } else {
         return next(dynamicNode, newMap);
       }

--- a/packages/relic_core/lib/src/router/relic_app.dart
+++ b/packages/relic_core/lib/src/router/relic_app.dart
@@ -192,6 +192,13 @@ final class RelicApp implements RelicRouter, _Reloadable {
     final NormalizedPath normalizedPath, {
     final bool backtrack = true,
   }) => delegate.lookupPath(method, normalizedPath, backtrack: backtrack);
+
+  @override
+  LookupResult<Handler> lookupUri(
+    final Method method,
+    final Uri url, {
+    final bool backtrack = true,
+  }) => delegate.lookupUri(method, url, backtrack: backtrack);
 }
 
 /// Developer tools for inspecting and debugging a [RelicApp].

--- a/packages/relic_core/lib/src/router/router.dart
+++ b/packages/relic_core/lib/src/router/router.dart
@@ -165,9 +165,9 @@ final class Router<T extends Object> {
 
   /// Looks up a route matching an already normalized [normalizedPath].
   ///
-  /// Use this when the caller has built the path from parts and must not have
-  /// them re-split, such as when a routing key is assembled from a host and a
-  /// request path.
+  /// Use when the caller already holds a normalized path (e.g. a routing key
+  /// assembled from host and path). Walks the trie directly; results are not
+  /// cached.
   LookupResult<T> lookupPath(
     final Method method,
     final NormalizedPath normalizedPath, {
@@ -181,6 +181,17 @@ final class Router<T extends Object> {
 
     return RouterMatch(route, entry.parameters, entry.matched, entry.remaining);
   }
+
+  /// Looks up a route for the [Uri] of a request.
+  ///
+  /// The entry point for request routing: derives the path via
+  /// [NormalizedPath.fromUri] (splitting before decoding, so an encoded
+  /// separator cannot alter routing), then looks it up with [lookupPath].
+  LookupResult<T> lookupUri(
+    final Method method,
+    final Uri url, {
+    final bool backtrack = true,
+  }) => lookupPath(method, NormalizedPath.fromUri(url), backtrack: backtrack);
 
   /// Returns true if the router has no routes.
   bool get isEmpty => _allRoutes.isEmpty;

--- a/packages/relic_core/test/router/no_cache_test.dart
+++ b/packages/relic_core/test/router/no_cache_test.dart
@@ -28,68 +28,32 @@ void main() {
     });
   });
 
-  group('Given NormalizedPath with NoCache', () {
-    late Cache<String, NormalizedPath> originalCache;
+  group('Given a Router (no result cache)', () {
+    test('when a request path is looked up twice '
+        'then routing works and the results are equal but not memoized', () {
+      final router = Router<int>()..get('/a/b', 1);
 
-    setUp(() {
-      originalCache = NormalizedPath.interned;
-      NormalizedPath.interned = const NoCache();
+      final first = router.lookupUri(Method.get, Uri.parse('/a/b'));
+      final second = router.lookupUri(Method.get, Uri.parse('/a/b'));
+
+      expect((first as RouterMatch<int>).value, equals(1));
+      expect((second as RouterMatch<int>).value, equals(1));
+      // No result cache: each lookup builds a fresh result.
+      expect(identical(first, second), isFalse);
     });
 
-    tearDown(() {
-      NormalizedPath.interned = originalCache;
-    });
+    test('when a route is added after a lookup '
+        'then the new route is found', () {
+      final router = Router<int>()..get('/a/b', 1);
 
-    test('when creating NormalizedPath '
-        'then normalization still works correctly', () {
-      final path = NormalizedPath('/a/b/c');
-      expect(path.segments, equals(['a', 'b', 'c']));
-      expect(path.toString(), equals('/a/b/c'));
-    });
+      expect(
+        router.lookupUri(Method.get, Uri.parse('/a/c')),
+        isA<PathMiss<int>>(),
+      );
 
-    test('when creating equivalent paths '
-        'then they are equal but not identical', () {
-      final path1 = NormalizedPath('/a/b');
-      final path2 = NormalizedPath('/a/b');
-      expect(path1, equals(path2));
-      expect(identical(path1, path2), isFalse);
-    });
-
-    test('when normalizing complex paths '
-        'then normalization is correct', () {
-      final path = NormalizedPath('/a/./b/../c');
-      expect(path.segments, equals(['a', 'c']));
-      expect(path.toString(), equals('/a/c'));
-    });
-  });
-
-  group('Given NormalizedPath with custom-sized LruCache', () {
-    late Cache<String, NormalizedPath> originalCache;
-
-    setUp(() {
-      originalCache = NormalizedPath.interned;
-      NormalizedPath.interned = LruCache<String, NormalizedPath>(2);
-    });
-
-    tearDown(() {
-      NormalizedPath.interned = originalCache;
-    });
-
-    test('when cache capacity is exceeded '
-        'then old entries are evicted', () {
-      final path1 = NormalizedPath('/a');
-      NormalizedPath('/b'); // fill cache
-      final path3 = NormalizedPath('/c');
-
-      // path1 should have been evicted from the small cache
-      final path1Again = NormalizedPath('/a');
-      expect(path1, equals(path1Again));
-      // With a cache of size 2, after /a, /b, /c, /a is evicted
-      // so creating /a again produces a new (non-identical) instance
-      expect(identical(path1, path1Again), isFalse);
-
-      // path3 and path2 should still be cached (or path3 and path1Again)
-      expect(identical(path3, NormalizedPath('/c')), isTrue);
+      router.get('/a/c', 2);
+      final hit = router.lookupUri(Method.get, Uri.parse('/a/c'));
+      expect((hit as RouterMatch<int>).value, equals(2));
     });
   });
 }

--- a/packages/relic_core/test/router/no_cache_test.dart
+++ b/packages/relic_core/test/router/no_cache_test.dart
@@ -27,33 +27,4 @@ void main() {
       expect(cache.length, equals(0));
     });
   });
-
-  group('Given a Router (no result cache)', () {
-    test('when a request path is looked up twice '
-        'then routing works and the results are equal but not memoized', () {
-      final router = Router<int>()..get('/a/b', 1);
-
-      final first = router.lookupUri(Method.get, Uri.parse('/a/b'));
-      final second = router.lookupUri(Method.get, Uri.parse('/a/b'));
-
-      expect((first as RouterMatch<int>).value, equals(1));
-      expect((second as RouterMatch<int>).value, equals(1));
-      // No result cache: each lookup builds a fresh result.
-      expect(identical(first, second), isFalse);
-    });
-
-    test('when a route is added after a lookup '
-        'then the new route is found', () {
-      final router = Router<int>()..get('/a/b', 1);
-
-      expect(
-        router.lookupUri(Method.get, Uri.parse('/a/c')),
-        isA<PathMiss<int>>(),
-      );
-
-      router.get('/a/c', 2);
-      final hit = router.lookupUri(Method.get, Uri.parse('/a/c'));
-      expect((hit as RouterMatch<int>).value, equals(2));
-    });
-  });
 }

--- a/packages/relic_core/test/router/normalized_path_test.dart
+++ b/packages/relic_core/test/router/normalized_path_test.dart
@@ -130,38 +130,36 @@ void main() {
     });
   });
 
-  group('Interning', () {
+  group('Pure value semantics', () {
     test('Given identical path strings, '
         'when creating NormalizedPath, '
-        'then returns identical instances', () {
+        'then instances are equal but not interned to one object', () {
       final path1 = NormalizedPath('/a/b');
       final path2 = NormalizedPath('/a/b');
-      expect(identical(path1, path2), isTrue);
+      expect(path1, equals(path2));
+      expect(identical(path1, path2), isFalse);
     });
 
     test('Given logically equivalent path strings, '
         'when creating NormalizedPath, '
-        'then returns identical instances', () {
+        'then instances are equal but not identical', () {
       final path1 = NormalizedPath('a/b'); // No leading slash
       final path2 = NormalizedPath('/a/b/'); // Leading and trailing slash
       final path3 = NormalizedPath('a/./b'); // Contains '.' segment
-      expect(identical(path1, path2), isTrue);
-      expect(identical(path1, path3), isTrue);
+      expect(path1, equals(path2));
+      expect(path1, equals(path3));
+      expect(identical(path1, path2), isFalse);
     });
 
     test('Given different logical paths, '
         'when creating NormalizedPath, '
-        'then returns different instances', () {
+        'then instances are not equal', () {
       final path1 = NormalizedPath('/a/b');
       final path2 = NormalizedPath('/a/c');
       final path3 = NormalizedPath('/a');
-      expect(identical(path1, path2), isFalse);
-      expect(identical(path1, path3), isFalse);
+      expect(path1, isNot(equals(path2)));
+      expect(path1, isNot(equals(path3)));
     });
-
-    // Note: The interning cache (LruCache) has a size limit.
-    // Testing eviction is complex and depends on the exact cache size and usage order.
-    // We focus on the core interning guarantee for reasonably accessed paths.
   });
 
   group('Equality and HashCode', () {

--- a/packages/relic_core/test/router/path_trie_test.dart
+++ b/packages/relic_core/test/router/path_trie_test.dart
@@ -186,6 +186,43 @@ void main() {
         expect(result.parameters, equals({#c: 'w'}));
       });
 
+      group('Given the same parameter name bound at two levels', () {
+        setUp(() {
+          trie.add(NormalizedPath('/:x/lit/:x/a'), 1);
+          trie.add(NormalizedPath('/:x/:y/c'), 2);
+        });
+
+        test('when the inner branch matches, '
+            'then the inner binding shadows the outer one', () {
+          final result = trie.lookup(NormalizedPath('/v/lit/w/a'));
+          expect(result, isNotNull);
+          expect(result!.value, equals(1));
+          expect(result.parameters, equals({#x: 'w'}));
+        });
+
+        test('when the inner branch fails, '
+            'then backtracking restores the outer binding', () {
+          final result = trie.lookup(NormalizedPath('/v/lit/c'));
+          expect(result, isNotNull);
+          expect(result!.value, equals(2));
+          expect(result.parameters, equals({#x: 'v', #y: 'lit'}));
+        });
+      });
+
+      test('Given a parameter route that leads to a dead end, '
+          'when an alternative without that parameter matches, '
+          'then the abandoned binding is not reported', () {
+        trie.add(NormalizedPath('/a/:x/b'), 1);
+        trie.add(NormalizedPath('/**'), 2);
+
+        // /a/v/c binds :x=v, dead-ends on 'c', then backtracks to the tail.
+        final result = trie.lookup(NormalizedPath('/a/v/c'));
+        expect(result, isNotNull);
+        expect(result!.value, equals(2));
+        expect(result.parameters, isEmpty);
+        expect(result.remaining.path, equals('/a/v/c'));
+      });
+
       test('Given backtracking scenario with no valid match, '
           'when all paths exhausted, '
           'then returns null', () {

--- a/packages/relic_core/test/router/router_groups_test.dart
+++ b/packages/relic_core/test/router/router_groups_test.dart
@@ -159,4 +159,30 @@ void main() {
     final router = Router<int>();
     expect(() => router.group('/api/**'), throwsArgumentError);
   });
+
+  group(
+    'Given routes needing backtracking added to a group after creation',
+    () {
+      late Router<int> router;
+
+      setUp(() {
+        router = Router<int>();
+        router.group('/api')
+          ..get('/users/x', 1)
+          ..get('/users/:id/y', 2);
+      });
+
+      test('when looking up through the parent, '
+          'then the parent backtracks into the group', () {
+        final result = router.lookup(Method.get, '/api/users/x/y');
+        expectLookupResult(result, 2, {#id: 'x'});
+      });
+
+      test('when looking up the literal route through the parent, '
+          'then it still wins over the parameter route', () {
+        final result = router.lookup(Method.get, '/api/users/x');
+        expectLookupResult(result, 1);
+      });
+    },
+  );
 }

--- a/packages/relic_core/test/router/router_test.dart
+++ b/packages/relic_core/test/router/router_test.dart
@@ -658,4 +658,20 @@ void main() {
       );
     });
   });
+
+  group('Given a Router looked up by Uri', () {
+    test('when a route is added after a lookup, '
+        'then the new route is found', () {
+      final router = Router<int>()..get('/a/b', 1);
+
+      expect(
+        router.lookupUri(Method.get, Uri.parse('/a/c')),
+        isA<PathMiss<int>>(),
+      );
+
+      router.get('/a/c', 2);
+      final hit = router.lookupUri(Method.get, Uri.parse('/a/c'));
+      expect((hit as RouterMatch<int>).value, equals(2));
+    });
+  });
 }


### PR DESCRIPTION
## Description

Remove NormalizedPath interning

This PR removes NormalizedPath interning completely.

Interning was originally added to avoid re-normalizing paths, but it always had two problems:

- A rather bad perf cliff: some inputs thrash the cache (#342).
- Per-isolate memory use: Dart makes it impossible (or very difficult) to share caches across isolates (#344).

On top of that, the new `NormalizedPath.fromSegments` and `NormalizedPath.fromUri` constructors - now the ones actually used on the request path - made interning tricky, so the security PRs (#369 & #371) simply skipped it for those paths.

Most of the lost performance is recouped by:

- Pre-computing repeated work.
- Extracting parameters into a single mutable map with undo-in-place during backtracking. Previously a copy was made at each parameter level so backtracking could just throw it away, but undoing in place avoids the copy and the allocation, reducing GC pressure.
- ~~Inferring from the registered routes whether backtracking is needed at all, and taking a faster non-backtracking walk when it isn't.~~

Results
```
┌────────┬─────────┬─────────┬────────────┐
│ routes │ Router  │ Spanner │ Routingkit │
├────────┼─────────┼─────────┼────────────┤
│ 1M     │ 1229 ns │ 1393 ns │ 3468 ns    │
├────────┼─────────┼─────────┼────────────┤
│ 100k   │ 994 ns  │ 1015 ns │ 3194 ns    │
├────────┼─────────┼─────────┼────────────┤
│ 10k    │ 579 ns  │ 402 ns  │ 1889 ns    │
└────────┴─────────┴─────────┴────────────┘
(measured on a 2.4 GHz 8-core Intel Core i9)
```

Fixes: #118 (not by improving caching, but by dropping it)
Fixes: #342 (this time by disabling interning altogether, instead of making caching opt-out)
Closes: #344 (investigation done)

## Breaking changes

- `NormalizedPath.interned` is removed